### PR TITLE
[CB-1388] Add reset() to plugin API and fix

### DIFF
--- a/src/blackberry10/index.js
+++ b/src/blackberry10/index.js
@@ -20,6 +20,7 @@
 */
 
 var audioObjects = {},
+    _ids = [],
     mediaErrorsHandled = false;
 
 // There is a bug in the webplatform handling of media error
@@ -78,6 +79,7 @@ module.exports = {
         }
 
         id = JSON.parse(decodeURIComponent(args[0]));
+        _ids.push(id);
 
         audio = audioObjects[id];
 
@@ -233,5 +235,16 @@ module.exports = {
         }
 
         result.ok();
+    },
+    
+    reset: function () {
+        _ids.forEach(function (id) {
+            if (audioObjects.hasOwnProperty(id)) {
+                audioObjects[id].pause();
+                audioObjects[id].currentTime = 0;
+            }
+        });
+        _ids = [];
+        audioObjects = {};
     }
 };


### PR DESCRIPTION
callback collisions on all platforms

Updated the BB10 media plugin to have remove
listeners on DocumentLoadCommitted.

BRWSR-12128
JIRA-430749
