### PR TITLE
[CB-4755] Fix crash in Media.setVolume on iOS

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -267,16 +267,15 @@
     NSString* mediaId = [command.arguments objectAtIndex:0];
     NSNumber* volume = [command.arguments objectAtIndex:1 withDefault:[NSNumber numberWithFloat:1.0]];
 
-    CDVAudioFile* audioFile;
-    if ([self soundCache] == nil) {
-        [self setSoundCache:[NSMutableDictionary dictionaryWithCapacity:1]];
-    } else {
-        audioFile = [[self soundCache] objectForKey:mediaId];
-        audioFile.volume = volume;
-        if (audioFile.player) {
-            audioFile.player.volume = [volume floatValue];
+    if ([self soundCache] != nil) {
+        CDVAudioFile* audioFile = [[self soundCache] objectForKey:mediaId];
+        if (audioFile != nil) {
+            audioFile.volume = volume;
+            if (audioFile.player) {
+                audioFile.player.volume = [volume floatValue];
+            }
+            [[self soundCache] setObject:audioFile forKey:mediaId];
         }
-        [[self soundCache] setObject:audioFile forKey:mediaId];
     }
 
     // don't care for any callbacks


### PR DESCRIPTION
Media.setVolume caused the application to crash after Media.release was called. Code causing crash:

```
var m = new Media("test.caf");
m.release();
m.setVolume(1); // crash in this call
```

The reason was that retrieving the CDVAudioFile instance from the sound cache would return nil after Media.release. This patch fixes the issue by explicitely checking for nil. It also does away with an unnecessary cache initialization, which isn't needed as -[Media setVolume:] doesn't write to the cache.
