### PR TITLE
CB-5748 Make sure that Media.onStatus is called when recording is started

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -561,6 +561,7 @@
                 if (recordingSuccess) {
                     NSLog(@"Started recording audio sample '%@'", audioFile.resourcePath);
                     jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%d);", @"cordova.require('org.apache.cordova.media.Media').onStatus", mediaId, MEDIA_STATE, MEDIA_RUNNING];
+                    [self.commandDelegate evalJs:jsString];
                 }
             }
             
@@ -575,6 +576,7 @@
                     [self.avSession setActive:NO error:nil];
                 }
                 jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('org.apache.cordova.media.Media').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_ABORTED message:errorMsg]];
+                [self.commandDelegate evalJs:jsString];
             }
         };
         


### PR DESCRIPTION
There are two instances in CDVSound.m where a javascript callback to Media.onStatus is setup, but never eval'd.  This means that under 3.3.0, when you start recording, you never get status updates on the media object.  The patch below just makes sure the javascript string is eval'd after getting setup.

I have tested this patch in a cordova app I have that relies on getting record status messages for proper functioning, and it is working with these two additions.
