### PR TITLE
Check if avSession.category is already set to "AVAudioSessionCategoryPlayAndRecord" before recording

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -555,7 +555,10 @@
             }
             // get the audioSession and set the category to allow recording when device is locked or ring/silent switch engaged
             if ([self hasAudioSession]) {
-                [self.avSession setCategory:AVAudioSessionCategoryRecord error:nil];
+                if (![self.avSession.category isEqualToString:AVAudioSessionCategoryPlayAndRecord]) {
+                    [self.avSession setCategory:AVAudioSessionCategoryRecord error:nil];
+                }
+                
                 if (![self.avSession setActive:YES error:&error]) {
                     // other audio with higher priority that does not allow mixing could cause this to fail
                     errorMsg = [NSString stringWithFormat:@"Unable to record audio: %@", [error localizedFailureReason]];


### PR DESCRIPTION
Check if avSession.category is already set to "AVAudioSessionCategoryPlayAndRecord" before recording, so as not to override it with "AVAudioSessionCategoryRecord". This way, applications that require to play media and record audio simultaneously, may do so in a straightforward manner; i.e. set the AVAudioSessionCategory to "AVAudioSessionCategoryPlayAndRecord", and then just play the media and start recording.
