### PR TITLE
CB-7638 Get audio duration properly on windows

### DIFF
--- a/src/windows8/MediaProxy.js
+++ b/src/windows8/MediaProxy.js
@@ -47,11 +47,17 @@ module.exports = {
                 fn === 'm3u' || fn === 'wmx' || fn === 'm4a') {
                 thisM.node = new Audio(src);
                 thisM.node.load();
-                var dur = thisM.node.duration;
-                if (isNaN(dur)) {
-                    dur = -1;
-                }
-                Media.onStatus(id, Media.MEDIA_DURATION, dur);
+
+                var getDuration = function () {
+                    var dur = thisM.node.duration;
+                    if (isNaN(dur)) {
+                        dur = -1;
+                    }
+                    Media.onStatus(id, Media.MEDIA_DURATION, dur);
+                };
+
+                thisM.node.onloadedmetadata = getDuration;
+                getDuration();
             }
             else {
                 lose && lose({code:MediaError.MEDIA_ERR_ABORTED});


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CB-7638

Proper way to get real audio duration is to use `onloadedmetadata` event for audio element to update duration of audio after successful loading.
