### PR TITLE
Fixed the problem with multiple sounds not playing at the same time

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -417,7 +417,7 @@
         NSLog(@"Failed to initialize AVAudioPlayer: %@\n", [playerError localizedDescription]);
         audioFile.player = nil;
         if (self.avSession) {
-            [self.avSession setActive:NO error:nil];
+//            [self.avSession setActive:NO error:nil];
         }
         bError = YES;
     } else {
@@ -508,7 +508,7 @@
                 [audioFile.recorder stop];
             }
             if (self.avSession) {
-                [self.avSession setActive:NO error:nil];
+//                [self.avSession setActive:NO error:nil];
                 self.avSession = nil;
             }
             [[self soundCache] removeObjectForKey:mediaId];
@@ -592,7 +592,7 @@
                 }
                 audioFile.recorder = nil;
                 if (self.avSession) {
-                    [self.avSession setActive:NO error:nil];
+//                    [self.avSession setActive:NO error:nil];
                 }
                 jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('org.apache.cordova.media.Media').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_ABORTED message:errorMsg]];
                 [self.commandDelegate evalJs:jsString];
@@ -612,7 +612,7 @@
                     NSLog(@"%@", msg);
                     audioFile.recorder = nil;
                     if (self.avSession) {
-                        [self.avSession setActive:NO error:nil];
+//                        [self.avSession setActive:NO error:nil];
                     }
                     jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('org.apache.cordova.media.Media').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_ABORTED message:msg]];
                     [self.commandDelegate evalJs:jsString];
@@ -666,7 +666,7 @@
         jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('org.apache.cordova.media.Media').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_DECODE message:nil]];
     }
     if (self.avSession) {
-        [self.avSession setActive:NO error:nil];
+//        [self.avSession setActive:NO error:nil];
     }
     [self.commandDelegate evalJs:jsString];
 }
@@ -689,7 +689,7 @@
         jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('org.apache.cordova.media.Media').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_DECODE message:nil]];
     }
     if (self.avSession) {
-        [self.avSession setActive:NO error:nil];
+//        [self.avSession setActive:NO error:nil];
     }
     [self.commandDelegate evalJs:jsString];
 }


### PR DESCRIPTION
The problem is visible on iOS 8 if someone wants to play multiple sounds at the same time. When one sound ends (is released) AVSession (that is a shared instance per app) is set not active, causing other playing sounds to stop playing.

My simple solution was to remove all calls where the shared app. AVSession is inactivated. Should not cause memory leaks since it's a shared instance.

Could be that this AVSession should be released when app is paused.