### PR TITLE
Add seekCompleteCallback to seekTo.

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -281,11 +281,12 @@ function for any `Media` resource that is no longer needed.
 
 Sets the current position within an audio file.
 
-    media.seekTo(milliseconds);
+    media.seekTo(milliseconds, seekCompleteCallback);
 
 ### Parameters
 
 - __milliseconds__: The position to set the playback position within the audio, in milliseconds.
+- __seekCompleteCallback__:  (Optional) The callback that executes after the `Media` object has completed the seek action. _(Function)_
 
 
 ### Quick Example

--- a/www/Media.js
+++ b/www/Media.js
@@ -89,10 +89,13 @@ Media.prototype.stop = function() {
 /**
  * Seek or jump to a new time in the track..
  */
-Media.prototype.seekTo = function(milliseconds) {
+Media.prototype.seekTo = function(milliseconds, seekCompleteCallback) {
     var me = this;
     exec(function(p) {
         me._position = p;
+        if ( seekCompleteCallback ) {
+            seekCompleteCallback( me._position );
+        }
     }, this.errorCallback, "Media", "seekToAudio", [this.id, milliseconds]);
 };
 


### PR DESCRIPTION
I had created an audio sprite elsewhere:

```
var sprite = new Media(/* omitted */);
sprite.play();
sprite.pause();
```

Then, further along, went to play the clip:

```
sprite.seekTo( track.startTime );
sprite.play();
```

In iOS 7 and below, as well as Android, this worked. However, in iOS 8, nothing would be played. When I inspected the position, `spirte._position`, a value of `-1` was shown. Basically, seeking to a position took some undetermined amount of time, and the audio couldn't be played until the seek had completed.

This pull request adds a callback to the `seekTo` method that is fired when the seek is complete.
