### PR TITLE
CB-8252 Fire audio events from native via message channel

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -44,7 +44,7 @@
 * CB-5128: add repo + issue tag to plugin.xml for media plugin
 * [CB-5010] Incremented plugin version on dev branch.
 
- 
+
 ### 0.2.6 (Dec 4, 2013)
 * [ubuntu] specify policy_group
 * add ubuntu platform
@@ -103,3 +103,7 @@
 * CB-7977 Mention `deviceready` in plugin docs
 * CB-7945 Made media.spec.15 and media.spec.16 auto tests green
 * CB-7700 cordova-plugin-media documentation translation: cordova-plugin-media
+
+### 0.2.16 (Jan 08, 2015)
+* CB-8252 **Android/Amazon**: Use message channel/PluginResult to send events from native -> Javascript. Removes all use of inline javascript/eval()s
+

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -27,6 +27,9 @@ import android.media.MediaRecorder;
 import android.os.Environment;
 import android.util.Log;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -133,7 +136,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         switch (this.mode) {
         case PLAY:
             Log.d(LOG_TAG, "AudioPlayer Error: Can't record in play mode.");
-            this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', "+MEDIA_ERROR+", { \"code\":"+MEDIA_ERR_ABORTED+"});");
+            sendErrorStatus(MEDIA_ERR_ABORTED);
             break;
         case NONE:
             this.audioFile = file;
@@ -152,11 +155,11 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                 e.printStackTrace();
             }
 
-            this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', "+MEDIA_ERROR+", { \"code\":"+MEDIA_ERR_ABORTED+"});");
+            sendErrorStatus(MEDIA_ERR_ABORTED);
             break;
         case RECORD:
             Log.d(LOG_TAG, "AudioPlayer Error: Already recording.");
-            this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', "+MEDIA_ERROR+", { \"code\":"+MEDIA_ERR_ABORTED+"});");
+            sendErrorStatus(MEDIA_ERR_ABORTED);
         }
     }
 
@@ -227,7 +230,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         if (this.readyPlayer(this.audioFile)) {
             this.player.seekTo(milliseconds);
             Log.d(LOG_TAG, "Send a onStatus update for the new seek");
-            this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', " + MEDIA_POSITION + ", " + milliseconds / 1000.0f + ");");
+            sendStatusChange(MEDIA_POSITION, null, (milliseconds / 1000.0f));
         }
         else {
             this.seekOnPrepared = milliseconds;
@@ -246,7 +249,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         }
         else {
             Log.d(LOG_TAG, "AudioPlayer Error: pausePlaying() called during invalid state: " + this.state.ordinal());
-            this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', " + MEDIA_ERROR + ", { \"code\":" + MEDIA_ERR_NONE_ACTIVE + "});");
+            sendErrorStatus(MEDIA_ERR_NONE_ACTIVE);
         }
     }
 
@@ -262,7 +265,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         }
         else {
             Log.d(LOG_TAG, "AudioPlayer Error: stopPlaying() called during invalid state: " + this.state.ordinal());
-            this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', " + MEDIA_ERROR + ", { \"code\":" + MEDIA_ERR_NONE_ACTIVE + "});");
+            sendErrorStatus(MEDIA_ERR_NONE_ACTIVE);
         }
     }
 
@@ -284,7 +287,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     public long getCurrentPosition() {
         if ((this.state == STATE.MEDIA_RUNNING) || (this.state == STATE.MEDIA_PAUSED)) {
             int curPos = this.player.getCurrentPosition();
-            this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', " + MEDIA_POSITION + ", " + curPos / 1000.0f + ");");
+            sendStatusChange(MEDIA_POSITION, null, (curPos / 1000.0f));
             return curPos;
         }
         else {
@@ -363,7 +366,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         this.prepareOnly = true;
 
         // Send status notification to JavaScript
-        this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', " + MEDIA_DURATION + "," + this.duration + ");");
+        sendStatusChange(MEDIA_DURATION, null, this.duration);
     }
 
     /**
@@ -391,7 +394,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         this.player.release();
 
         // Send error notification to JavaScript
-        this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', { \"code\":" + arg1 + "});");
+        sendErrorStatus(arg1);
         return false;
     }
 
@@ -402,7 +405,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
      */
     private void setState(STATE state) {
         if (this.state != state) {
-            this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', " + MEDIA_STATE + ", " + state.ordinal() + ");");
+            sendStatusChange(MEDIA_STATE, null, (float)state.ordinal());
         }
         this.state = state;
     }
@@ -410,7 +413,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     /**
      * Set the mode and send it to JavaScript.
      *
-     * @param state
+     * @param mode
      */
     private void setMode(MODE mode) {
         if (this.mode != mode) {
@@ -451,7 +454,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             break;
         case RECORD:
             Log.d(LOG_TAG, "AudioPlayer Error: Can't play in record mode.");
-            this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', " + MEDIA_ERROR + ", { \"code\":" + MEDIA_ERR_ABORTED + "});");
+            sendErrorStatus(MEDIA_ERR_ABORTED);
             return false; //player is not ready
         }
         return true;
@@ -472,7 +475,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                     try {
                         this.loadAudioFile(file);
                     } catch (Exception e) {
-                        this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', "+MEDIA_ERROR+", { \"code\":"+MEDIA_ERR_ABORTED+"});");
+                        sendErrorStatus(MEDIA_ERR_ABORTED);
                     }
                     return false;
                 case MEDIA_LOADING:
@@ -497,14 +500,14 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                         try {
                             this.loadAudioFile(file);
                         } catch (Exception e) {
-                            this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', " + MEDIA_ERROR + ", { \"code\":" + MEDIA_ERR_ABORTED + "});");
+                            sendErrorStatus(MEDIA_ERR_ABORTED);
                         }
-                        //if we had to prepare= the file, we won't be in the correct state for playback
+                        //if we had to prepare the file, we won't be in the correct state for playback
                         return false;
                     }
                 default:
                     Log.d(LOG_TAG, "AudioPlayer Error: startPlaying() called during invalid state: " + this.state);
-                    this.handler.webView.sendJavascript("cordova.require('org.apache.cordova.media.Media').onStatus('" + this.id + "', " + MEDIA_ERROR + ", { \"code\":" + MEDIA_ERR_ABORTED + "});");
+                    sendErrorStatus(MEDIA_ERR_ABORTED);
             }
         }
         return false;
@@ -551,5 +554,34 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                 // Get duration
                 this.duration = getDurationInSeconds();
             }
+    }
+
+    private void sendErrorStatus(int errorCode) {
+        sendStatusChange(MEDIA_ERROR, errorCode, null);
+    }
+
+    private void sendStatusChange(int messageType, Integer additionalCode, Float value) {
+
+        if (additionalCode != null && value != null) {
+            throw new IllegalArgumentException("Only one of additionalCode or value can be specified, not both");
+        }
+
+        JSONObject statusDetails = new JSONObject();
+        try {
+            statusDetails.put("id", this.id);
+            statusDetails.put("msgType", messageType);
+            if (additionalCode != null) {
+                JSONObject code = new JSONObject();
+                code.put("code", additionalCode.intValue());
+                statusDetails.put("value", code);
+            }
+            else if (value != null) {
+                statusDetails.put("value", value.floatValue());
+            }
+        } catch (JSONException e) {
+            Log.e(LOG_TAG, "Failed to create status details", e);
+        }
+
+        this.handler.sendEventMessage("status", statusDetails);
     }
 }

--- a/www/Media.js
+++ b/www/Media.js
@@ -193,3 +193,24 @@ Media.onStatus = function(id, msgType, value) {
 };
 
 module.exports = Media;
+
+function onMessageFromNative(msg) {
+    if (msg.action == 'status') {
+        Media.onStatus(msg.status.id, msg.status.msgType, msg.status.value);
+    } else {
+        throw new Error('Unknown media action' + msg.action);
+    }
+}
+
+if (cordova.platformId === 'android' || cordova.platformId === 'amazon-fireos') {
+
+    var channel = require('cordova/channel');
+
+    channel.createSticky('onMediaPluginReady');
+    channel.waitForInitialization('onMediaPluginReady');
+
+    channel.onCordovaReady.subscribe(function() {
+        exec(onMessageFromNative, undefined, 'Media', 'messageChannel', []);
+        channel.initializationComplete('onMediaPluginReady');
+    });
+}


### PR DESCRIPTION
- Add startup logic to initialize a message channel for native -> Javascript
- Applies only to android and amazon-fireos (as this reuses the android native code)
- Change audio status events to send via plugin message channel, instead
using eval() (i.e. webView.sendJavascript())