### PR TITLE
CB-8686 - remove musicLibrary capability

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -154,7 +154,6 @@ id="org.apache.cordova.media"
         </js-module>
 
         <config-file target="package.appxmanifest" parent="/Package/Capabilities">
-            <Capability Name="musicLibrary" />
             <DeviceCapability Name="microphone" />
         </config-file>
     </platform>
@@ -166,7 +165,6 @@ id="org.apache.cordova.media"
         </js-module>
 
         <config-file target="package.appxmanifest" parent="/Package/Capabilities">
-            <Capability Name="musicLibrary" />
             <DeviceCapability Name="microphone" />
         </config-file>
     </platform>


### PR DESCRIPTION
Media plugin by default requests musicLibrary capability but it's not using it. It should be removed since, it's not required.