### PR TITLE
CB-8793 Increased playback timeout in tests

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -19,7 +19,7 @@
  *
  */
 // increased timeout for actual playback to give device chance to download and play mp3 file
-var ACTUAL_PLAYBACK_TEST_TIMEOUT = 10000;
+var ACTUAL_PLAYBACK_TEST_TIMEOUT = 30000;
  
 var isWindows = cordova.platformId == 'windows8' || cordova.platformId == 'windows';
 // detect whether audio hardware is available and enabled


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-8793

Sometimes (on a slow emulators) spec.16 still fails because it couldn't start playing in time. This fixes it.