### PR TITLE
CB-9079 Increased timeout for playback tests

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -19,7 +19,8 @@
  *
  */
 // increased timeout for actual playback to give device chance to download and play mp3 file
-var ACTUAL_PLAYBACK_TEST_TIMEOUT = 30000;
+// some emulators can be REALLY slow at this, so two minutes
+var ACTUAL_PLAYBACK_TEST_TIMEOUT = 2 * 60 * 1000;
  
 var isWindows = cordova.platformId == 'windows8' || cordova.platformId == 'windows';
 // detect whether audio hardware is available and enabled


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-9079

This is a fix for failing tests on http://ci.apache.org/builders/cordova-android-win

I was unable to reproduce the failures on any of my devices or emulators, but given that spec.17 fails with "Error creating Media object" message, I am pretty confident that this is a timeout issue.