### PR TITLE
fix record and play NullPointerException

### DIFF
--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -490,10 +490,24 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                 case MEDIA_STOPPED:
                     //if we are readying the same file
                     if (this.audioFile.compareTo(file) == 0) {
-                        //reset the audio file
-                        player.seekTo(0);
-                        player.pause();
-                        return true;
+                        //maybe it was recording?
+                        if(this.recorder!=null && player==null) {
+                            this.player = new MediaPlayer();
+                            this.prepareOnly = false;
+
+                            try {
+                                this.loadAudioFile(file);
+                            } catch (Exception e) {
+                                sendErrorStatus(MEDIA_ERR_ABORTED);
+                            }
+                            return false;//we´re not ready yet
+                        } 
+                        else {
+                           //reset the audio file
+                            player.seekTo(0);
+                            player.pause();
+                            return true; 
+                        } 
                     } else {
                         //reset the player
                         this.player.reset();


### PR DESCRIPTION
I´ve came across a use case where i always get a NullPointerException:

1 - Start recording audio file
2 - Stop recording
3 - Play the recorded file

When the recording ends, the status is set to "MEDIA_STOPPED", if i try to play the recorded file right afterwards, a NullPointerException is thrown at line 494 of readyPlayer(...). This happens because the file name is the same as the audioFile, and the corresponding switch/case assumes that in this case it means that this particular file has already been played before, which is not true. At this point there is no "player" object but only a "recorder", therefore the exception. With a simple check on the recorder and player it is possible to play the newly recorded file without any issues.

On IOS there is no issue with this use case, only android.