### PR TITLE
CB-8222 Background threading for Audio Plugin

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -253,6 +253,8 @@
 
 - (void)startPlayingAudio:(CDVInvokedUrlCommand*)command
 {
+    [self.commandDelegate runInBackground:^{
+
     NSString* callbackId = command.callbackId;
 
 #pragma unused(callbackId)
@@ -330,6 +332,7 @@
     }
     // else audioFile was nil - error already returned from audioFile for resource
     return;
+    }];
 }
 
 - (BOOL)prepareToPlay:(CDVAudioFile*)audioFile withId:(NSString*)mediaId


### PR DESCRIPTION
Start playback with background thread so that UI is not blocked when playing sounds with the media plugin.