### PR TITLE
More background threading for audio

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -214,6 +214,7 @@
 
 - (void)create:(CDVInvokedUrlCommand*)command
 {
+    [self.commandDelegate runInBackground:^{
     NSString* mediaId = [command argumentAtIndex:0];
     NSString* resourcePath = [command argumentAtIndex:1];
 
@@ -227,10 +228,12 @@
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
     }
+    }];
 }
 
 - (void)setVolume:(CDVInvokedUrlCommand*)command
 {
+    [self.commandDelegate runInBackground:^{
     NSString* callbackId = command.callbackId;
 
 #pragma unused(callbackId)
@@ -247,7 +250,7 @@
             [[self soundCache] setObject:audioFile forKey:mediaId];
         }
     }
-
+    }];
     // don't care for any callbacks
 }
 
@@ -459,6 +462,7 @@
 
 - (void)release:(CDVInvokedUrlCommand*)command
 {
+    [self.commandDelegate runInBackground:^{
     NSString* mediaId = [command argumentAtIndex:0];
 
     if (mediaId != nil) {
@@ -478,6 +482,7 @@
             NSLog(@"Media with id %@ released", mediaId);
         }
     }
+    }];
 }
 
 - (void)getCurrentPositionAudio:(CDVInvokedUrlCommand*)command

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -253,6 +253,8 @@
 
 - (void)startPlayingAudio:(CDVInvokedUrlCommand*)command
 {
+    [self.commandDelegate runInBackground:^{
+
     NSString* callbackId = command.callbackId;
 
 #pragma unused(callbackId)
@@ -330,6 +332,7 @@
     }
     // else audioFile was nil - error already returned from audioFile for resource
     return;
+    }];
 }
 
 - (BOOL)prepareToPlay:(CDVAudioFile*)audioFile withId:(NSString*)mediaId

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -387,6 +387,7 @@
 
 - (void)stopPlayingAudio:(CDVInvokedUrlCommand*)command
 {
+    [self.commandDelegate runInBackground:^{
     NSString* mediaId = [command argumentAtIndex:0];
     CDVAudioFile* audioFile = [[self soundCache] objectForKey:mediaId];
     NSString* jsString = nil;
@@ -400,10 +401,12 @@
     if (jsString) {
         [self.commandDelegate evalJs:jsString];
     }
+    }];
 }
 
 - (void)pausePlayingAudio:(CDVInvokedUrlCommand*)command
 {
+    [self.commandDelegate runInBackground:^{
     NSString* mediaId = [command argumentAtIndex:0];
     NSString* jsString = nil;
     CDVAudioFile* audioFile = [[self soundCache] objectForKey:mediaId];
@@ -418,6 +421,7 @@
     if (jsString) {
         [self.commandDelegate evalJs:jsString];
     }
+    }];
 }
 
 - (void)seekToAudio:(CDVInvokedUrlCommand*)command
@@ -426,6 +430,7 @@
     // 0 = Media id
     // 1 = path to resource
     // 2 = seek to location in milliseconds
+    [self.commandDelegate runInBackground:^{
 
     NSString* mediaId = [command argumentAtIndex:0];
 
@@ -449,6 +454,7 @@
 
         [self.commandDelegate evalJs:jsString];
     }
+    }];
 }
 
 - (void)release:(CDVInvokedUrlCommand*)command
@@ -476,6 +482,7 @@
 
 - (void)getCurrentPositionAudio:(CDVInvokedUrlCommand*)command
 {
+    [self.commandDelegate runInBackground:^{
     NSString* callbackId = command.callbackId;
     NSString* mediaId = [command argumentAtIndex:0];
 
@@ -491,6 +498,7 @@
     NSString* jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%.3f);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_POSITION, position];
     [self.commandDelegate evalJs:jsString];
     [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }];
 }
 
 - (void)startRecordingAudio:(CDVInvokedUrlCommand*)command
@@ -632,6 +640,7 @@
 
 - (void)audioPlayerDidFinishPlaying:(AVAudioPlayer*)player successfully:(BOOL)flag
 {
+    [self.commandDelegate runInBackground:^{
     CDVAudioPlayer* aPlayer = (CDVAudioPlayer*)player;
     NSString* mediaId = aPlayer.mediaId;
     CDVAudioFile* audioFile = [[self soundCache] objectForKey:mediaId];
@@ -651,6 +660,7 @@
         [self.avSession setActive:NO error:nil];
     }
     [self.commandDelegate evalJs:jsString];
+    }];
 }
 
 - (void)onMemoryWarning


### PR DESCRIPTION
send more functions to background threads.

The previous submission fixes the UI blocking on load from URL with play(), xcode still complains that other functions take too long and should use background threads even though this is much less noticeable as the delays are far shorter than loading an entire audio file from a URL they should still be backgrounded.

this adds further backgrounding for most other playback methods.  I haven't changed record as I have not been working with record and hence not been able to test.

These changes work well on iphone5,6,ipad2 and the ios emulator and keep xcode happy.