### PR TITLE
Streaming & Background threading on play

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
 id="cordova-plugin-media"
-    version="1.0.2-dev">
+    version="1.0.3-dev">
 
     <name>Media</name>
     <description>Cordova Media Plugin</description>

--- a/src/ios/CDVSound.h
+++ b/src/ios/CDVSound.h
@@ -6,9 +6,7 @@
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
-
  http://www.apache.org/licenses/LICENSE-2.0
-
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -85,10 +83,13 @@ typedef NSUInteger CDVMediaMsg;
 @interface CDVSound : CDVPlugin <AVAudioPlayerDelegate, AVAudioRecorderDelegate>
 {
     NSMutableDictionary* soundCache;
+    NSString* currMediaId;
     AVAudioSession* avSession;
+    AVPlayer* avPlayer;
 }
 @property (nonatomic, strong) NSMutableDictionary* soundCache;
 @property (nonatomic, strong) AVAudioSession* avSession;
+@property (nonatomic, strong) NSString* currMediaId;
 
 - (void)startPlayingAudio:(CDVInvokedUrlCommand*)command;
 - (void)pausePlayingAudio:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -337,8 +337,8 @@
             if (!bError) {
                 NSLog(@"Playing audio sample '%@'", audioFile.resourcePath);
                 double position = 0;
-                if (avPlayer) {
-                    CMTime time = [avPlayer currentTime];
+                if (avPlayer.currentItem && avPlayer.currentItem.asset) {
+                    CMTime time = avPlayer.currentItem.asset.duration;
                     position = CMTimeGetSeconds(time);
                     NSLog(@"Playing stream with AVPlayer");
                     [avPlayer play];
@@ -364,7 +364,7 @@
                     }
 
                     [audioFile.player play];
-                    //double position = round(audioFile.player.duration * 1000) / 1000;
+                    position = round(audioFile.player.duration * 1000) / 1000;
                 }
 
                 jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%.3f);\n%@(\"%@\",%d,%d);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_DURATION, position, @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_STATE, MEDIA_RUNNING];

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -458,7 +458,17 @@
         [audioFile.player stop];
         audioFile.player.currentTime = 0;
         jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%d);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_STATE, MEDIA_STOPPED];
-    }  // ignore if no media playing
+    }
+    if (avPlayer.currentItem && avPlayer.currentItem.asset) {
+        NSLog(@"Stopped playing audio sample '%@'", audioFile.resourcePath);
+        [avPlayer pause];
+        [avPlayer seekToTime: kCMTimeZero
+                     toleranceBefore: kCMTimeZero
+                      toleranceAfter: kCMTimeZero
+                   completionHandler: ^(BOOL finished)];
+        jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%d);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_STATE, MEDIA_STOPPED];
+    }
+    // ignore if no media playing
     if (jsString) {
         [self.commandDelegate evalJs:jsString];
     }

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -461,11 +461,12 @@
     }
     if (avPlayer.currentItem && avPlayer.currentItem.asset) {
         NSLog(@"Stopped playing audio sample '%@'", audioFile.resourcePath);
-        [avPlayer pause];
         [avPlayer seekToTime: kCMTimeZero
                      toleranceBefore: kCMTimeZero
                       toleranceAfter: kCMTimeZero
-                   completionHandler: ^(BOOL finished)];
+                   completionHandler: ^(BOOL finished){
+                           if (finished) [avPlayer pause];
+                       }];
         jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%d);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_STATE, MEDIA_STOPPED];
     }
     // ignore if no media playing

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -286,6 +286,11 @@
                 audioFile.player.enableRate = YES;
                 audioFile.player.rate = [rate floatValue];
             }
+            if (avPlayer.currentItem && avPlayer.currentItem.asset){
+                float customRate = [rate floatValue];
+                [avPlayer setRate:customRate];
+            }
+            
             [[self soundCache] setObject:audioFile forKey:mediaId];
         }
     }

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -341,12 +341,14 @@
                     CMTime time = avPlayer.currentItem.asset.duration;
                     position = CMTimeGetSeconds(time);
 
+                    audioFile.player.enableRate = YES;
+
                     if (audioFile.rate != nil){
-                        float customRate = [audioFile.rate floatValue];
+                        audioFile.player.rate = [audioFile.rate floatValue];
                         NSLog(@"Playing stream with AVPlayer & custom rate");
-                        [avPlayer setRate:customRate];
+                        [avPlayer setRate:audioFile.player.rate];
                     } else {
-                        NSLog(@"Playing stream with AVPlayer & custom rate");
+                        NSLog(@"Playing stream with AVPlayer");
                         [avPlayer play];
                     }
 

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -341,14 +341,12 @@
                     CMTime time = avPlayer.currentItem.asset.duration;
                     position = CMTimeGetSeconds(time);
 
-                    audioFile.player.enableRate = YES;
-
                     if (audioFile.rate != nil){
-                        audioFile.player.rate = [audioFile.rate floatValue];
+                        float customRate = [audioFile.rate floatValue];
                         NSLog(@"Playing stream with AVPlayer & custom rate");
-                        [avPlayer setRate:audioFile.player.rate];
+                        [avPlayer setRate:customRate];
                     } else {
-                        NSLog(@"Playing stream with AVPlayer");
+                        NSLog(@"Playing stream with AVPlayer & custom rate");
                         [avPlayer play];
                     }
 

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -340,8 +340,16 @@
                 if (avPlayer.currentItem && avPlayer.currentItem.asset) {
                     CMTime time = avPlayer.currentItem.asset.duration;
                     position = CMTimeGetSeconds(time);
-                    NSLog(@"Playing stream with AVPlayer");
-                    [avPlayer play];
+
+                    if (audioFile.rate != nil){
+                        float customRate = [audioFile.rate floatValue];
+                        NSLog(@"Playing stream with AVPlayer & custom rate");
+                        [avPlayer setRate:customRate];
+                    } else {
+                        NSLog(@"Playing stream with AVPlayer & custom rate");
+                        [avPlayer play];
+                    }
+
                 } else {
 
                     NSNumber* loopOption = [options objectForKey:@"numberOfLoops"];


### PR DESCRIPTION
This fixes 2 issues in the Cordova Jira, both with iOS.  It enables streaming support for media playback from URLs while retaining the existing playback for local media.

The second part is the simply background thread the play function so it doesn't block the ui or lock up the app on load.  Gets rid of some of those pesky warnings in xcode too.

Tested with simulator and on iphone 5 and iphone 6 and ipad 2, with iOS 8.1, 8.3 & 8.4

Please merge these and bump the version of the media plugin so I can stop installing them from my own fork :)

Fix for CB-57
Updated to use avplayer when url starts with http:// or https:// for
full streaming support.

All other urls will use the standard AVAudioplayer

Fix for CB-8222
Background thread on play to prevent locking during initial load of
media.