### PR TITLE
CB-9452: Treat RTSP streams as remote URLs

### DIFF
--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -303,7 +303,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
      * @return                  T=streaming, F=local
      */
     public boolean isStreaming(String file) {
-        if (file.contains("http://") || file.contains("https://")) {
+        if (file.contains("http://") || file.contains("https://") || file.contains("rtsp://")) {
             return true;
         }
         else {


### PR DESCRIPTION
Cordova Media plugin fails to play when attempting to play an RTSP stream. The stream is treated as a local resource so in AudioPlayer.java:305.