### PR TITLE
CB-9605 Fixes issue with playback resume after pause on WP8

### DIFF
--- a/src/wp/AudioPlayer.cs
+++ b/src/wp/AudioPlayer.cs
@@ -277,7 +277,7 @@ namespace WPCordovaClassLib.Cordova.Commands
             }
 
 
-            if (this.player == null || this.player.Source.AbsolutePath.LastIndexOf(filePath) < 0)
+            if (this.player == null || this.player.Source.AbsoluteUri.LastIndexOf(filePath) < 0)
             {
                 try
                 {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -257,6 +257,44 @@ exports.defineAutoTests = function () {
                 media = new Media(mediaFile, successCallback, failed.bind(self, done, 'media1 = new Media - Error creating Media object. Media file: ' + mediaFile, context), statusChange);
                 media.play();
             }, ACTUAL_PLAYBACK_TEST_TIMEOUT);
+
+            it("media.spec.20 should be able to resume playback after pause", function (done) {
+                if (!isAudioSupported || cordova.platformId === 'blackberry10') {
+                    pending();
+                }
+
+                //context variable used as an extra security statement to ensure that the callback is processed only once,
+                //in case the statusChange callback is reached more than one time with the same status code.
+                //Some information about this kind of behaviour can be found at JIRA: CB-7099.
+                var context = this;
+                var resumed = false;
+                var mediaFile = 'http://cordova.apache.org/downloads/BlueZedEx.mp3';
+                var successCallback = function () { };
+                var statusChange = function (statusCode) {
+                    if (context.done) return;
+
+                    if (statusCode == Media.MEDIA_RUNNING) {
+                        if (!resumed) {
+                            media.seekTo(20000);
+                            media.pause();
+                            return;
+                        }
+
+                        media.getCurrentPosition(function (position) {
+                            expect(position).toBe(20);
+                            context.done = true;
+                            done();
+                        }, failed.bind(null, done, 'media1.getCurrentPosition - Error getting media current position', context))
+                    }
+
+                    if (statusCode == Media.MEDIA_PAUSED) {
+                        resumed = true;
+                        media.play();
+                    }
+                };
+                media = new Media(mediaFile, successCallback, failed.bind(self, done, 'media1 = new Media - Error creating Media object. Media file: ' + mediaFile, context), statusChange);
+                media.play();
+            }, ACTUAL_PLAYBACK_TEST_TIMEOUT);
         });
 
         it("media.spec.18 should contain a setRate function", function () {


### PR DESCRIPTION
This fixes [CB-9605](https://issues.apache.org/jira/browse/CB-9605)

In case of playing remote file, specified by URL (instead of local path) `player.Source.AbsolutePath` is a last part of original URL and thus `AbsolutePath.LastIndexOf(filePath)` always -1:

    AbsoluteUri = "http://cordova.apache.org/downloads/BlueZedEx.mp3"
    AbsolutePath = "/downloads/BlueZedEx.mp3"

So, using an `AbsoluteUri` looks more reasonable and works for both local files and remote URLs.