### PR TITLE
Fixed example referencing non-existent variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Pauses playing an audio file.
 
         // Pause after 10 seconds
         setTimeout(function () {
-            media.pause();
+            my_media.pause();
         }, 10000);
     }
 


### PR DESCRIPTION
Fixed example referencing non-existent variable media, fixed to use my_media variable.