### PR TITLE
CB-10476 - fix problem where callbacks were not invoked on android du…

### DIFF
--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -100,7 +100,6 @@ public class AudioHandler extends CordovaPlugin {
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         CordovaResourceApi resourceApi = webView.getResourceApi();
         PluginResult.Status status = PluginResult.Status.OK;
-        messageChannel = callbackContext;
         String result = "";
 
         if (action.equals("startRecordingAudio")) {


### PR DESCRIPTION
seems like the faulty code was added back in this commit:

https://github.com/apache/cordova-plugin-media/commit/c4547c94c5850c619b0936551ec1180f4465a95b#diff-ea1d1dcd03fa62ee9f2774edbf524977

line 121.

problem happens when messageChannel is reset with callbackContext every call... removing this will fix the problem.