### PR TITLE
CB-10535: Fix Plugin Media crash due to seeking before buffering of file is completed

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -543,13 +543,23 @@
         CMTime timeToSeek = CMTimeMakeWithSeconds(posInSeconds, timeScale);
            
         BOOL isPlaying = (avPlayer.rate > 0 && !avPlayer.error);
-            
-        [avPlayer seekToTime: timeToSeek
-                        toleranceBefore: kCMTimeZero
-                        toleranceAfter: kCMTimeZero
-                    completionHandler: ^(BOOL finished) {
-                        if (isPlaying) [avPlayer play];
-                    }];
+        BOOL isReadyToSeek = (avPlayer.status == AVPlayerStatusReadyToPlay) && (avPlayer.currentItem.status == AVPlayerItemStatusReadyToPlay);
+        
+        // CB-10535:
+        // When dealing with remote files, we can get into a situation where we start playing before AVPlayer has had the time to buffer the file to be played.
+        // To avoid the app crashing in such a situation, we only seek if both the player and the player item are ready to play. If not ready, we send an error back to JS land.
+        if(isReadyToSeek) {
+            [avPlayer seekToTime: timeToSeek
+                 toleranceBefore: kCMTimeZero
+                  toleranceAfter: kCMTimeZero
+               completionHandler: ^(BOOL finished) {
+                   if (isPlaying) [avPlayer play];
+               }];
+        } else {
+            CDVMediaError errcode = MEDIA_ERR_ABORTED;
+            NSString* errMsg = @"AVPlayerItem cannot service a seek request with a completion handler until its status is AVPlayerItemStatusReadyToPlay.";
+            jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:errcode message:errMsg]];
+        }
     }
 
     [self.commandDelegate evalJs:jsString];

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -515,8 +515,7 @@
 {
     // args:
     // 0 = Media id
-    // 1 = path to resource
-    // 2 = seek to location in milliseconds
+    // 1 = seek to location in milliseconds
 
     NSString* mediaId = [command argumentAtIndex:0];
 
@@ -539,22 +538,22 @@
             // NSLog(@"seekJsString=%@",jsString);
         }
 
-        } else if (avPlayer != nil) {
-            int32_t timeScale = avPlayer.currentItem.asset.duration.timescale;
-            CMTime timeToSeek = CMTimeMakeWithSeconds(posInSeconds, timeScale);            
+    } else if (avPlayer != nil) {
+        int32_t timeScale = avPlayer.currentItem.asset.duration.timescale;
+        CMTime timeToSeek = CMTimeMakeWithSeconds(posInSeconds, timeScale);
            
-            BOOL isPlaying = (avPlayer.rate > 0 && !avPlayer.error);
+        BOOL isPlaying = (avPlayer.rate > 0 && !avPlayer.error);
             
-            [avPlayer seekToTime: timeToSeek
-                         toleranceBefore: kCMTimeZero
-                          toleranceAfter: kCMTimeZero
-                       completionHandler: ^(BOOL finished) {
-                           if (isPlaying) [avPlayer play];
-                       }];
-        }
-
-        [self.commandDelegate evalJs:jsString];
+        [avPlayer seekToTime: timeToSeek
+                        toleranceBefore: kCMTimeZero
+                        toleranceAfter: kCMTimeZero
+                    completionHandler: ^(BOOL finished) {
+                        if (isPlaying) [avPlayer play];
+                    }];
     }
+
+    [self.commandDelegate evalJs:jsString];
+}
 
 
 - (void)release:(CDVInvokedUrlCommand*)command

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -209,7 +209,7 @@ exports.defineAutoTests = function () {
                 //in case the statusChange callback is reached more than one time with the same status code.
                 //Some information about this kind of behaviour can be found at JIRA: CB-7099.
                 var context = this,
-                    mediaFile = 'http://cordova.apache.org/downloads/BlueZedEx.mp3',
+                    mediaFile = 'https://cordova.apache.org/downloads/BlueZedEx.mp3',
                     successCallback = function () { },
                     statusChange = function (statusCode) {
                         if (!context.done && statusCode == Media.MEDIA_RUNNING) {
@@ -238,7 +238,7 @@ exports.defineAutoTests = function () {
                 //in case the statusChange callback is reached more than one time with the same status code.
                 //Some information about this kind of behaviour can be found at JIRA: CB-7099.
                 var context = this,
-                    mediaFile = 'http://cordova.apache.org/downloads/BlueZedEx.mp3',
+                    mediaFile = 'https://cordova.apache.org/downloads/BlueZedEx.mp3',
                     successCallback = function () { },
                     statusChange = function (statusCode) {
                         if (!context.done && statusCode == Media.MEDIA_RUNNING) {
@@ -268,7 +268,7 @@ exports.defineAutoTests = function () {
                 //Some information about this kind of behaviour can be found at JIRA: CB-7099.
                 var context = this;
                 var resumed = false;
-                var mediaFile = 'http://cordova.apache.org/downloads/BlueZedEx.mp3';
+                var mediaFile = 'https://cordova.apache.org/downloads/BlueZedEx.mp3';
                 var successCallback = function () { };
                 var statusChange = function (statusCode) {
                     if (context.done) return;
@@ -305,7 +305,7 @@ exports.defineAutoTests = function () {
                 //in case the statusChange callback is reached more than one time with the same status code.
                 //Some information about this kind of behaviour can be found at JIRA: CB-7099.
                 var context = this;
-                var mediaFile = 'http://cordova.apache.org/downloads/BlueZedEx.mp3';
+                var mediaFile = 'https://cordova.apache.org/downloads/BlueZedEx.mp3';
                 var successCallback = function () { };
                 var statusChange = function (statusCode) {
                     if (!context.done && statusCode == Media.MEDIA_RUNNING) {
@@ -338,7 +338,7 @@ exports.defineAutoTests = function () {
                 pending();
                 return;
             }
-            var mediaFile = 'http://cordova.apache.org/downloads/BlueZedEx.mp3',
+            var mediaFile = 'https://cordova.apache.org/downloads/BlueZedEx.mp3',
                 mediaState = Media.MEDIA_STOPPED,
                 successCallback,
                 context = this,
@@ -381,7 +381,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     var media1 = null;
     var media1Timer = null;
     var audioSrc = null;
-    var defaultaudio = "http://cordova.apache.org/downloads/BlueZedEx.mp3";
+    var defaultaudio = "https://cordova.apache.org/downloads/BlueZedEx.mp3";
 
     //Play audio function
     function playAudio(url) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -293,7 +293,12 @@ exports.defineAutoTests = function () {
                     }
                 };
                 media = new Media(mediaFile, successCallback, failed.bind(self, done, 'media1 = new Media - Error creating Media object. Media file: ' + mediaFile, context), statusChange);
-                media.play();
+                
+                // CB-10535: Play after a few secs, to give allow enough buffering of media file before seeking
+                setTimeout(function() {
+                    media.play();
+                }, 4000);
+                
             }, ACTUAL_PLAYBACK_TEST_TIMEOUT);
 
             it("media.spec.21 should be able to seek through file", function (done) {
@@ -321,7 +326,12 @@ exports.defineAutoTests = function () {
                     }
                 };
                 media = new Media(mediaFile, successCallback, failed.bind(self, done, 'media1 = new Media - Error creating Media object. Media file: ' + mediaFile, context), statusChange);
-                media.play();
+                
+                // CB-10535: Play after a few secs, to give allow enough buffering of media file before seeking
+                setTimeout(function() {
+                    media.play();
+                }, 4000);
+                
             }, ACTUAL_PLAYBACK_TEST_TIMEOUT);
         });
 


### PR DESCRIPTION
When dealing with remote files, we can get into a situation where we start playing before the native iOS components (AVPlayer & AVPlayerItem) have had the time to buffer the file to be played.
To avoid the app crashing in such a situation, we only seek if both the player and the player item are ready.