### PR TITLE
CB-7684: (iOS) Fix CDVSound killing all audio when a single file finishes

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -180,7 +180,7 @@
     return audioFile;
 }
 
-// returns whether or not audioSession is available - creates it if necessary
+// returns whether or not audioSession is available - retrieve the instance (app singleton) if necessary
 - (BOOL)hasAudioSession
 {
     BOOL bSession = YES;
@@ -191,7 +191,7 @@
         self.avSession = [AVAudioSession sharedInstance];
         if (error) {
             // is not fatal if can't get AVAudioSession , just log the error
-            NSLog(@"error creating audio session: %@", [[error userInfo] description]);
+            NSLog(@"error retrieving audio session: %@", [[error userInfo] description]);
             self.avSession = nil;
             bSession = NO;
         }
@@ -447,9 +447,6 @@
     if (playerError != nil) {
         NSLog(@"Failed to initialize AVAudioPlayer: %@\n", [playerError localizedDescription]);
         audioFile.player = nil;
-        if (self.avSession) {
-            [self.avSession setActive:NO error:nil];
-        }
         bError = YES;
     } else {
         audioFile.player.mediaId = mediaId;
@@ -586,7 +583,6 @@
                 avPlayer = nil;
             }
             if (self.avSession) {
-                [self.avSession setActive:NO error:nil];
                 self.avSession = nil;
             }
             [[self soundCache] removeObjectForKey:mediaId];
@@ -685,9 +681,6 @@
                     errorMsg = @"Failed to start recording using AVAudioRecorder";
                 }
                 audioFile.recorder = nil;
-                if (weakSelf.avSession) {
-                    [weakSelf.avSession setActive:NO error:nil];
-                }
                 jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_ERROR, [weakSelf createMediaErrorWithCode:MEDIA_ERR_ABORTED message:errorMsg]];
                 [weakSelf.commandDelegate evalJs:jsString];
             }
@@ -705,9 +698,6 @@
                     NSString* msg = @"Error creating audio session, microphone permission denied.";
                     NSLog(@"%@", msg);
                     audioFile.recorder = nil;
-                    if (weakSelf.avSession) {
-                        [weakSelf.avSession setActive:NO error:nil];
-                    }
                     jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_ABORTED message:msg]];
                     [weakSelf.commandDelegate evalJs:jsString];
                 }
@@ -759,9 +749,6 @@
         // jsString = [NSString stringWithFormat: @"%@(\"%@\",%d,%d);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_ERROR, MEDIA_ERR_DECODE];
         jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_DECODE message:nil]];
     }
-    if (self.avSession) {
-        [self.avSession setActive:NO error:nil];
-    }
     [self.commandDelegate evalJs:jsString];
 }
 
@@ -783,9 +770,6 @@
         // jsString = [NSString stringWithFormat: @"%@(\"%@\",%d,%d);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_ERROR, MEDIA_ERR_DECODE];
         jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_DECODE message:nil]];
     }
-    if (self.avSession) {
-        [self.avSession setActive:NO error:nil];
-    }
     [self.commandDelegate evalJs:jsString];
 }
 
@@ -795,9 +779,6 @@
     NSString* jsString = nil;
     jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%d);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_STATE, MEDIA_STOPPED];
 
-    if (self.avSession) {
-        [self.avSession setActive:NO error:nil];
-    }
     [self.commandDelegate evalJs:jsString];
 }
 


### PR DESCRIPTION
### Platforms affected

iOS
### What does this PR do?

We arrived to the same conclusion as Nathan Stryker on Jira (https://issues.apache.org/jira/browse/CB-7684) and @ionut-movila in the PR https://github.com/apache/cordova-plugin-media/pull/33 : all `self.avSession setActive:NO` should be removed.

The problem was not only that when a media finishes it is stopping other ones played by the plugin, but it is also killing any sound played by another plugin or by WebView's default webaudio system, triggering a descriptive:

```
AVAudioSession.mm:646: -[AVAudioSession setActive:withOptions:error:]: Deactivating an audio session that has running I/O. All I/O should be stopped or paused prior to deactivating the audio session.
```

We found that `AVAudioSession` is a singleton for the whole app (cf. https://developer.apple.com/library/ios/documentation/AVFoundation/Reference/AVAudioSession_ClassReference/).

Apple says:

> Most apps never need to deactivate their audio session explicitly. Important exceptions include VoIP (Voice over Internet Protocol) apps, turn-by-turn navigation apps, and, in some cases, recording apps.

(cf. https://developer.apple.com/library/ios/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/ConfiguringanAudioSession/ConfiguringanAudioSession.html)
### What testing has been done on this change?
- Played multiple sounds (non streaming) with the plugin, then waited for one to stop: it is not stopping other sounds anymore.
- Played multiple sounds (non streaming) with the plugin, then stopped one and released it: it is not stopping other sounds anymore.
- Played a sound (non streaming) with the plugin and another one via webview's webaudio, then waited the one played by the plugin to end: it is not stopping other sounds anymore.
- Played a sound (non streaming) with the plugin and another one via webview's webaudio, then stopped and released the one played by the plugin: it is not stopping other sounds anymore.
- Checked all possibilities with Xcode monitoring application: no memory issue detected.

Ran the integrated tests. Before doing any change (version 2.3.1-dev) the result was:

![cordova-media-plugin 2 3 1-dev](https://cloud.githubusercontent.com/assets/637734/16144330/252582c8-34ad-11e6-9932-cdb8ce8e05e5.jpg)

After the change the result is exactly the same:

![cordova-media-plugin cb-7684](https://cloud.githubusercontent.com/assets/637734/16144343/35490008-34ad-11e6-98bd-90d7c86becc3.jpg)

All tests was made with an iPad2 on iOS8.4.

Before merging, it would be great if someone can test:
- an application using the recording feature
- an application using the streaming feature
### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

About the last point: I don't see what kind of tests we can add for this fix.
