### PR TITLE
CB-11409: (iOS) New method allowing to disable automated memory release on memoryWarning

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ The following constants are reported as the only parameter to the
 
 - __duration__: The duration of the media, in seconds.
 
+### Class methods
+
+- `Media.shouldReleaseOnMemoryWarning`: Define if the plugin should automatically release its resources when a memory warnings is received (iOS).
 
 ## media.getCurrentAmplitude
 
@@ -670,3 +673,25 @@ function when an error occurs.
 - `MediaError.MEDIA_ERR_NETWORK`        = 2
 - `MediaError.MEDIA_ERR_DECODE`         = 3
 - `MediaError.MEDIA_ERR_NONE_SUPPORTED` = 4
+
+## Media.shouldReleaseOnMemoryWarning
+
+Static method to define if the plugin should automatically stop all sounds and release all possible resources when a memory warning is received. Default value is `true`.
+
+    Media.shouldReleaseOnMemoryWarning(status);
+
+### Parameters
+
+- __status__: Boolean value
+
+### Supported Platforms
+
+
+- iOS
+
+### Quick Example
+
+```js
+Media.shouldReleaseOnMemoryWarning(false);
+// Here comes custom code to handle memoryWarnings
+```

--- a/src/ios/CDVSound.h
+++ b/src/ios/CDVSound.h
@@ -91,10 +91,13 @@ typedef NSUInteger CDVMediaMsg;
 @property (nonatomic, strong) AVAudioSession* avSession;
 @property (nonatomic, strong) NSString* currMediaId;
 
+- (void)pluginInitialize;
+
 - (void)startPlayingAudio:(CDVInvokedUrlCommand*)command;
 - (void)pausePlayingAudio:(CDVInvokedUrlCommand*)command;
 - (void)stopPlayingAudio:(CDVInvokedUrlCommand*)command;
 - (void)seekToAudio:(CDVInvokedUrlCommand*)command;
+- (void)shouldReleaseOnMemoryWarning:(CDVInvokedUrlCommand*)command;
 - (void)release:(CDVInvokedUrlCommand*)command;
 - (void)getCurrentPositionAudio:(CDVInvokedUrlCommand*)command;
 - (void)resumeRecordingAudio:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -29,6 +29,13 @@
 
 @synthesize soundCache, avSession, currMediaId;
 
+static BOOL releaseOnMemoryWarning;
+
+- (void)pluginInitialize
+{
+    releaseOnMemoryWarning = false;
+}
+
 // Maps a url for a resource path for recording
 - (NSURL*)urlForRecording:(NSString*)resourcePath
 {
@@ -565,6 +572,10 @@
     [self.commandDelegate evalJs:jsString];
 }
 
+- (void)shouldReleaseOnMemoryWarning:(CDVInvokedUrlCommand*)command
+{
+    releaseOnMemoryWarning = [[command argumentAtIndex:0] boolValue];
+}
 
 - (void)release:(CDVInvokedUrlCommand*)command
 {
@@ -808,9 +819,11 @@
 
 - (void)onMemoryWarning
 {
-    [[self soundCache] removeAllObjects];
-    [self setSoundCache:nil];
-    [self setAvSession:nil];
+    if (releaseOnMemoryWarning) {
+        [[self soundCache] removeAllObjects];
+        [self setSoundCache:nil];
+        [self setAvSession:nil];
+    }
 
     [super onMemoryWarning];
 }

--- a/www/Media.js
+++ b/www/Media.js
@@ -233,6 +233,19 @@ Media.onStatus = function(id, msgType, value) {
 
 };
 
+/**
+ * Define if the plugin should release its resources automatically when a memory warning is received (iOS only)
+ */
+Media.shouldReleaseOnMemoryWarning = function(value) {
+    if (cordova.platformId === 'ios'){
+        exec(null, function () {
+            console.warn('Unable to set memory warning auto-release flag');
+        }, "Media", "shouldReleaseOnMemoryWarning", [value]);
+    } else {
+        console.warn('Media.shouldReleaseOnMemoryWarning method is currently not supported for', cordova.platformId, 'platform.');
+    }
+};
+
 module.exports = Media;
 
 function onMessageFromNative(msg) {


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

It is adding a method allowing the user to disable (and re-enable) the automated resource releasing when a memory warning is received on iOS. Why? Because user may want to handle memory warnings by himself (such as releasing other less important resource first).

This method is static, on the class:

```js
Media.shouldReleaseOnMemoryWarning(false);
// Here comes custom code to handle memoryWarnings
```

### What testing has been done on this change?

- Played multiple (non streaming) audio files after having disabled the auto-release and while having some heavy memory process running, until a memoryWarning is received: audio continue to play.
- Played multiple (non streaming) audio files with the auto-release enabled and while having some heavy memory process running, until a memoryWarning is received: audio stops.

Ran the integrated tests. Before doing any change (version 2.3.1-dev) the result was:

![cordova-media-plugin 2 3 1-dev](https://cloud.githubusercontent.com/assets/637734/16145899/3ca50f5a-34b6-11e6-924c-f04b87e7a1d1.jpg)

After the change the result is exactly the same:

![img_0194](https://cloud.githubusercontent.com/assets/637734/16145928/57cf7b9e-34b6-11e6-94a5-e44a38068688.jpg)

All tests was made with an iPad2 on iOS8.4.

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

About the last point: tests will come as soon as possible, meanwhile please have a look at the code and review it! Thank you.