### PR TITLE
CB-11429 Update infinite audio stream URL in tests

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -417,7 +417,8 @@ exports.defineAutoTests = function () {
                 pending();
             }
 
-            var mediaFile = 'http://209.73.138.20:80',
+            // The link below points to an infinite mp3 stream
+            var mediaFile = 'http://c22033-l.i.core.cdn.streamfarm.net/22033mdr/live/3087mdr_figaro/ch_classic_128.mp3',
                 successCallback,
                 context = this,
                 flag = true,


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All

### What does this PR do?
The PR changes audio stream URL used in tests to be allowed to play on Windows in order to make media.spec.25 'should be able to play an audio stream' passing on Windows

### What testing has been done on this change?
Ran auto tests for all main platforms

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

