### PR TITLE
CB-11085 (Android) Fixed AudioHandler logs should use system log, not println

### DIFF
--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -396,7 +396,7 @@ public class AudioHandler extends CordovaPlugin {
             audiMgr.setRouting(AudioManager.MODE_NORMAL, AudioManager.ROUTE_EARPIECE, AudioManager.ROUTE_ALL);
         }
         else {
-             Log.e(TAG1," Unknown output device");
+             LOG.e(TAG1," Unknown output device");
         }
     }
 
@@ -445,7 +445,7 @@ public class AudioHandler extends CordovaPlugin {
                                           AudioManager.AUDIOFOCUS_GAIN);
 
         if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-            Log.e(TAG2,result + " instead of " + AudioManager.AUDIOFOCUS_REQUEST_GRANTED);
+            LOG.e(TAG2,result + " instead of " + AudioManager.AUDIOFOCUS_REQUEST_GRANTED);
         }
 
     }
@@ -483,7 +483,7 @@ public class AudioHandler extends CordovaPlugin {
         if (audio != null) {
             audio.setVolume(volume);
         } else {
-          Log.e(TAG3,"Unknown Audio Player " + id);
+          LOG.e(TAG3,"Unknown Audio Player " + id);
         }
     }
 

--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -386,6 +386,8 @@ public class AudioHandler extends CordovaPlugin {
      */
     @SuppressWarnings("deprecation")
     public void setAudioOutputDevice(int output) {
+        private static final String TAG1 = "AudioHandler.setAudioOutputDevice(): Error : ";
+
         AudioManager audiMgr = (AudioManager) this.cordova.getActivity().getSystemService(Context.AUDIO_SERVICE);
         if (output == 2) {
             audiMgr.setRouting(AudioManager.MODE_NORMAL, AudioManager.ROUTE_SPEAKER, AudioManager.ROUTE_ALL);
@@ -394,7 +396,7 @@ public class AudioHandler extends CordovaPlugin {
             audiMgr.setRouting(AudioManager.MODE_NORMAL, AudioManager.ROUTE_EARPIECE, AudioManager.ROUTE_ALL);
         }
         else {
-            System.out.println("AudioHandler.setAudioOutputDevice() Error: Unknown output device.");
+             Log.e(TAG1," Unknown output device");
         }
     }
 
@@ -435,13 +437,15 @@ public class AudioHandler extends CordovaPlugin {
         };
 
     public void getAudioFocus() {
+        private static final String TAG2 = "AudioHandler.getAudioFocus(): Error : ";
+
         AudioManager am = (AudioManager) this.cordova.getActivity().getSystemService(Context.AUDIO_SERVICE);
         int result = am.requestAudioFocus(focusChangeListener,
                                           AudioManager.STREAM_MUSIC,
                                           AudioManager.AUDIOFOCUS_GAIN);
 
         if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-            System.out.println("AudioHandler.getAudioFocus() Error: Got " + result + " instead of " + AudioManager.AUDIOFOCUS_REQUEST_GRANTED);
+            Log.e(TAG2,result + " instead of " + AudioManager.AUDIOFOCUS_REQUEST_GRANTED);
         }
 
     }
@@ -473,11 +477,13 @@ public class AudioHandler extends CordovaPlugin {
      * @param volume            Volume to adjust to 0.0f - 1.0f
      */
     public void setVolume(String id, float volume) {
+        private static final String TAG3 = "AudioHandler.setVolume(): Error : ";
+
         AudioPlayer audio = this.players.get(id);
         if (audio != null) {
             audio.setVolume(volume);
         } else {
-            System.out.println("AudioHandler.setVolume() Error: Unknown Audio Player " + id);
+          Log.e(TAG3,"Unknown Audio Player " + id);
         }
     }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
This is a fix for https://issues.apache.org/jira/browse/CB-11085.
It fixes the println to LOG (android.util.Log use in org.apache.cordova.LOG).

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
