### PR TITLE
CB-11380 (ios) Fixed an unexpected error callback when initializing M…

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -131,7 +131,7 @@
 }
 
 // Creates or gets the cached audio file resource object
-- (CDVAudioFile*)audioFileForResource:(NSString*)resourcePath withId:(NSString*)mediaId doValidation:(BOOL)bValidate forRecording:(BOOL)bRecord
+- (CDVAudioFile*)audioFileForResource:(NSString*)resourcePath withId:(NSString*)mediaId doValidation:(BOOL)bValidate forRecording:(BOOL)bRecord suppressValidationErrors:(BOOL)bSuppress
 {
     BOOL bError = NO;
     CDVMediaError errcode = MEDIA_ERR_NONE_SUPPORTED;
@@ -164,7 +164,7 @@
         } else {
             resourceURL = [self urlForPlaying:resourcePath];
         }
-        if (resourceURL == nil) {
+        if ((resourceURL == nil) && !bSuppress) {
             bError = YES;
             errcode = MEDIA_ERR_ABORTED;
             errMsg = [NSString stringWithFormat:@"Cannot use audio file from resource '%@'", resourcePath];
@@ -217,7 +217,7 @@
     NSString* mediaId = [command argumentAtIndex:0];
     NSString* resourcePath = [command argumentAtIndex:1];
 
-    CDVAudioFile* audioFile = [self audioFileForResource:resourcePath withId:mediaId doValidation:YES forRecording:NO];
+    CDVAudioFile* audioFile = [self audioFileForResource:resourcePath withId:mediaId doValidation:YES forRecording:NO suppressValidationErrors:YES];
 
     if (audioFile == nil) {
         NSString* errorMessage = [NSString stringWithFormat:@"Failed to initialize Media file with path %@", resourcePath];
@@ -313,7 +313,7 @@
     BOOL bError = NO;
     NSString* jsString = nil;
 
-    CDVAudioFile* audioFile = [self audioFileForResource:resourcePath withId:mediaId doValidation:YES forRecording:NO];
+    CDVAudioFile* audioFile = [self audioFileForResource:resourcePath withId:mediaId doValidation:YES forRecording:NO suppressValidationErrors:NO];
     if ((audioFile != nil) && (audioFile.resourceURL != nil)) {
         if (audioFile.player == nil) {
             bError = [self prepareToPlay:audioFile withId:mediaId];
@@ -636,7 +636,7 @@
 #pragma unused(callbackId)
 
     NSString* mediaId = [command argumentAtIndex:0];
-    CDVAudioFile* audioFile = [self audioFileForResource:[command argumentAtIndex:1] withId:mediaId doValidation:YES forRecording:YES];
+    CDVAudioFile* audioFile = [self audioFileForResource:[command argumentAtIndex:1] withId:mediaId doValidation:YES forRecording:YES suppressValidationErrors:NO];
     __block NSString* jsString = nil;
     __block NSString* errorMsg = @"";
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -685,15 +685,14 @@ exports.defineManualTests = function (contentEl, createActionButton) {
 
     //Record audio
     function recordAudio() {
-        console.log("recordAudio()");
+        console.log("recordAudio(), recording to " + recordSrc);
         console.log(" -- media=" + mediaRec);
 
         releaseAudio();
 
         if (!mediaRec) {
-            var src = recordSrc;
-            mediaRec = new Media(src,
-                    function () {
+            mediaRec = new Media(recordSrc,
+                function () {
                     console.log("recordAudio():Audio Success");
                 },
                     function (err) {
@@ -731,22 +730,16 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         playAudio(recordSrc);
     }
 
-    //Function to create a file for iOS recording
-
+    //Function to get a filename for iOS recording
+    //Ensures that file doesn't exist to test CB-11380
     function getRecordSrc() {
-        var fsFail = function (error) {
-            console.log("error creating file for iOS recording");
-        };
-        var gotFile = function (file) {
-            recordSrc = file.fullPath;
-            //console.log("recording Src: " + recordSrc);
-        };
-        var gotFS = function (fileSystem) {
-            fileSystem.root.getFile("iOSRecording.wav", {
-                create : true
-            }, gotFile, fsFail);
-        };
-        window.requestFileSystem(LocalFileSystem.TEMPORARY, 0, gotFS, fsFail);
+        var noop = function () {};
+        recordSrc = "cdvfile://localhost/temporary/iOSRecording.wav";
+        window.resolveLocalFileSystemURL(recordSrc, function (file) {
+            file.remove(function() {
+                console.log("Successfully removed " + recordSrc);
+            }, noop);
+        }, noop);
     }
 
     //Function to create a file for BB recording


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Eliminates an unexpected error callback when initializing Media with the file that doesn't exist:
https://issues.apache.org/jira/browse/CB-11380

### What testing has been done on this change?
Tested manually on iOS 8.1

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

