### PR TITLE
CB-11757 (ios) Error out if trying to stop playback while in a wrong …

### DIFF
--- a/src/ios/CDVSound.h
+++ b/src/ios/CDVSound.h
@@ -22,6 +22,7 @@
 #import <Cordova/CDVPlugin.h>
 
 enum CDVMediaError {
+    MEDIA_ERR_NONE_ACTIVE = 0,
     MEDIA_ERR_ABORTED = 1,
     MEDIA_ERR_NETWORK = 2,
     MEDIA_ERR_DECODE = 3,

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -495,7 +495,10 @@
                }];
             jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%d);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_STATE, MEDIA_STOPPED];
         } else {
-            // cannot seek, do nothing
+            // cannot seek, wrong state
+            CDVMediaError errcode = MEDIA_ERR_NONE_ACTIVE;
+            NSString* errMsg = @"Cannot service stop request until the avPlayer is in 'AVPlayerStatusReadyToPlay' state.";
+            jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-media.Media').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:errcode message:errMsg]];
         }
     }
     // ignore if no media playing


### PR DESCRIPTION

### Platforms affected
ios

### What does this PR do?
https://issues.apache.org/jira/browse/CB-11757
Makes ios implementation to send error callback when trying to stop the playback when the avPlayer is not yet ready.

### What testing has been done on this change?
Manual and automated testing on iPad 2 with iOS 8.1
Also ran modified automated tests on Android 4.4 Emulator and on desktop Windows 10.

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
