### PR TITLE
CB-11817: (iOS) Fix unused recording settings

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -682,7 +682,7 @@
                                              AVNumberOfChannelsKey: @(1),
                                              AVEncoderAudioQualityKey: @(AVAudioQualityMedium)
                                              };
-            audioFile.recorder = [[CDVAudioRecorder alloc] initWithURL:audioFile.resourceURL settings:nil error:&error];
+            audioFile.recorder = [[CDVAudioRecorder alloc] initWithURL:audioFile.resourceURL settings:audioSettings error:&error];
 
             bool recordingSuccess = NO;
             if (error == nil) {


### PR DESCRIPTION
### Platforms affected

iOS
### What does this PR do?

easy fix: audioSettings object wasn't being passed in when starting a recording.
### What testing has been done on this change?

run automated tests, run in custom app.  All works as expected.
build in xcode.  Cleared up 2 warnings for an unused variable and null argument passed to recorder.
### Checklist
- [X ] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [ X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
