### PR TITLE
CB-11641 android: add 'message' field to media error

### DIFF
--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -142,10 +142,11 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
      * @param file              The name of the file
      */
     public void startRecording(String file) {
+        String errorMessage;
         switch (this.mode) {
         case PLAY:
-            LOG.d(LOG_TAG, "AudioPlayer Error: Can't record in play mode.");
-            sendErrorStatus(MEDIA_ERR_ABORTED);
+            errorMessage = "AudioPlayer Error: Can't record in play mode.";
+            sendErrorStatus(MEDIA_ERR_ABORTED, errorMessage);
             break;
         case NONE:
             this.audioFile = file;
@@ -169,8 +170,8 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             sendErrorStatus(MEDIA_ERR_ABORTED);
             break;
         case RECORD:
-            LOG.d(LOG_TAG, "AudioPlayer Error: Already recording.");
-            sendErrorStatus(MEDIA_ERR_ABORTED);
+            errorMessage = "AudioPlayer Error: Already recording.";
+            sendErrorStatus(MEDIA_ERR_ABORTED, errorMessage);
         }
     }
 
@@ -332,8 +333,8 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             this.setState(STATE.MEDIA_PAUSED);
         }
         else {
-            LOG.d(LOG_TAG, "AudioPlayer Error: pausePlaying() called during invalid state: " + this.state.ordinal());
-            sendErrorStatus(MEDIA_ERR_NONE_ACTIVE);
+            String errorMessage = "AudioPlayer Error: pausePlaying() called during invalid state: " + this.state.ordinal();
+            sendErrorStatus(MEDIA_ERR_NONE_ACTIVE, errorMessage);
         }
     }
 
@@ -348,8 +349,8 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             this.setState(STATE.MEDIA_STOPPED);
         }
         else {
-            LOG.d(LOG_TAG, "AudioPlayer Error: stopPlaying() called during invalid state: " + this.state.ordinal());
-            sendErrorStatus(MEDIA_ERR_NONE_ACTIVE);
+            String errorMessage = "AudioPlayer Error: stopPlaying() called during invalid state: " + this.state.ordinal();
+            sendErrorStatus(MEDIA_ERR_NONE_ACTIVE, errorMessage);
         }
     }
 
@@ -471,14 +472,14 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
      * @param arg2              an extra code, specific to the error.
      */
     public boolean onError(MediaPlayer player, int arg1, int arg2) {
-        LOG.d(LOG_TAG, "AudioPlayer.onError(" + arg1 + ", " + arg2 + ")");
+        String errorMessage = "AudioPlayer.onError(" + arg1 + ", " + arg2 + ")";
 
         // we don't want to send success callback
         // so we don't call setState() here
         this.state = STATE.MEDIA_STOPPED;
         this.destroy();
         // Send error notification to JavaScript
-        sendErrorStatus(arg1);
+        sendErrorStatus(arg1, errorMessage);
 
         return false;
     }
@@ -526,8 +527,8 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         if (this.player != null) {
             this.player.setVolume(volume, volume);
         } else {
-            LOG.d(LOG_TAG, "AudioPlayer Error: Cannot set volume until the audio file is initialized.");
-            sendErrorStatus(MEDIA_ERR_NONE_ACTIVE);
+            String errorMessage = "AudioPlayer Error: Cannot set volume until the audio file is initialized.";
+            sendErrorStatus(MEDIA_ERR_NONE_ACTIVE, errorMessage);
         }
     }
 
@@ -543,8 +544,8 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         case PLAY:
             break;
         case RECORD:
-            LOG.d(LOG_TAG, "AudioPlayer Error: Can't play in record mode.");
-            sendErrorStatus(MEDIA_ERR_ABORTED);
+            String errorMessage = "AudioPlayer Error: Can't play in record mode.";
+            sendErrorStatus(MEDIA_ERR_ABORTED, errorMessage);
             return false; //player is not ready
         }
         return true;
@@ -566,7 +567,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                     try {
                         this.loadAudioFile(file);
                     } catch (Exception e) {
-                        sendErrorStatus(MEDIA_ERR_ABORTED);
+                        sendErrorStatus(MEDIA_ERR_ABORTED, e.getMessage());
                     }
                     return false;
                 case MEDIA_LOADING:
@@ -590,7 +591,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                             try {
                                 this.loadAudioFile(file);
                             } catch (Exception e) {
-                                sendErrorStatus(MEDIA_ERR_ABORTED);
+                                sendErrorStatus(MEDIA_ERR_ABORTED, e.getMessage());
                             }
                             return false;//we´re not ready yet
                         }
@@ -606,14 +607,14 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                         try {
                             this.loadAudioFile(file);
                         } catch (Exception e) {
-                            sendErrorStatus(MEDIA_ERR_ABORTED);
+                            sendErrorStatus(MEDIA_ERR_ABORTED, e.getMessage());
                         }
                         //if we had to prepare the file, we won't be in the correct state for playback
                         return false;
                     }
                 default:
-                    LOG.d(LOG_TAG, "AudioPlayer Error: startPlaying() called during invalid state: " + this.state);
-                    sendErrorStatus(MEDIA_ERR_ABORTED);
+                    String errorMessage = "AudioPlayer Error: startPlaying() called during invalid state: " + this.state;
+                    sendErrorStatus(MEDIA_ERR_ABORTED, errorMessage);
             }
         }
         return false;
@@ -664,6 +665,22 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
 
     private void sendErrorStatus(int errorCode) {
         sendStatusChange(MEDIA_ERROR, errorCode, null);
+    }
+
+    private void sendErrorStatus(Integer errorCode, String errorMessage) {
+        LOG.d(LOG_TAG, errorMessage);
+        JSONObject statusDetails = new JSONObject();
+        try {
+            statusDetails.put("id", this.id);
+            statusDetails.put("msgType", MEDIA_ERROR);
+            JSONObject code = new JSONObject();
+            error.put("code", errorCode);
+            error.put("message", errorMessage);
+            statusDetails.put("value", error);
+        } catch (JSONException e) {
+            LOG.e(LOG_TAG, "Failed to create status details", e);
+        }
+        this.handler.sendEventMessage("status", statusDetails);
     }
 
     private void sendStatusChange(int messageType, Integer additionalCode, Float value) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -217,6 +217,23 @@ exports.defineAutoTests = function () {
             badMedia.play();
         });
 
+        it("media.spec.19 MediaError instance should contain 'code' and 'message' fields", function(done) {
+            var context = this,
+            fileName = 'invalid.file.name',
+            badMedia = new Media(fileName, succeed.bind(null, done, ' badMedia = new Media , Unexpected succees callback, it should not create Media object with invalid file name'), function (result) {
+                if (context.done) return;
+                context.done = true;
+                expect(result).toBeDefined();
+                expect(result.code).toBeDefined();
+                expect(result.message).toBeDefined();
+                if (badMedia) {
+                    badMedia.release();
+                }
+                done();
+            });
+            badMedia.play();
+        });
+
         describe('actual playback', function() {
             var checkInterval,
                 media;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
### Platforms affected

Android
### What does this PR do?

It was not possible before to get error message.This updated Android implementation to return error code with message similar to iOS.
### What testing has been done on this change?

Auto test
### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
