### PR TITLE
CB-12034 (ios) Add mandatory iOS 10 privacy description

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ function recordAudio() {
 
     // Pause Recording after 5 seconds
     setTimeout(function() {
-        my_media.pauseRecord();
+        mediaRec.pauseRecord();
     }, 5000);
 }
 ```
@@ -427,12 +427,12 @@ function recordAudio() {
 
     // Pause Recording after 5 seconds
     setTimeout(function() {
-        my_media.pauseRecord();
+        mediaRec.pauseRecord();
     }, 5000);
 
     // Resume Recording after 10 seconds
     setTimeout(function() {
-        my_media.resumeRecord();
+        mediaRec.resumeRecord();
     }, 10000);
 }
 ```
@@ -562,6 +562,14 @@ function recordAudio() {
 - Files can be recorded and played back using the documents URI:
 
         var myMedia = new Media("documents://beer.mp3")
+
+- Since iOS 10 it's mandatory to add a `NSMicrophoneUsageDescription` entry in the info.plist.
+
+`NSMicrophoneUsageDescription` describes the reason that the app accesses the user’s microphone. When the system prompts the user to allow access, this string is displayed as part of the dialog box. To add this entry you can pass the variable `MICROPHONE_USAGE_DESCRIPTION` on plugin install.
+
+Example: `cordova plugin add cordova-plugin-media --variable MICROPHONE_USAGE_DESCRIPTION="your usage message"`
+
+If you don't pass the variable, the plugin will add an empty string as value.
 
 ### Windows Quirks
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -59,7 +59,7 @@ id="cordova-plugin-media"
         <source-file src="src/android/AudioHandler.java" target-dir="src/org/apache/cordova/media" />
         <source-file src="src/android/AudioPlayer.java" target-dir="src/org/apache/cordova/media" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/media" />
-     </platform>
+    </platform>
 
      <!-- amazon-fireos -->
     <platform name="amazon-fireos">
@@ -79,31 +79,35 @@ id="cordova-plugin-media"
         <source-file src="src/android/AudioHandler.java" target-dir="src/org/apache/cordova/media" />
         <source-file src="src/android/AudioPlayer.java" target-dir="src/org/apache/cordova/media" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/media" />
-     </platform>
+    </platform>
 
 
-     <!-- ubuntu -->
-     <platform name="ubuntu">
-         <config-file target="config.xml" parent="/*">
-             <feature name="Media">
-                 <param policy_group="microphone" policy_version="1" />
-                 <param policy_group="video" policy_version="1" />
-             </feature>
-         </config-file>
-         <header-file src="src/ubuntu/media.h" />
-         <source-file src="src/ubuntu/media.cpp" />
-     </platform>
+    <!-- ubuntu -->
+    <platform name="ubuntu">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Media">
+                <param policy_group="microphone" policy_version="1" />
+                <param policy_group="video" policy_version="1" />
+            </feature>
+        </config-file>
+        <header-file src="src/ubuntu/media.h" />
+        <source-file src="src/ubuntu/media.cpp" />
+    </platform>
 
-     <!-- ios -->
-     <platform name="ios">
-         <config-file target="config.xml" parent="/*">
-             <feature name="Media">
-                 <param name="ios-package" value="CDVSound" />
-             </feature>
-         </config-file>
-         <header-file src="src/ios/CDVSound.h" />
-         <source-file src="src/ios/CDVSound.m" />
-     </platform>
+    <!-- ios -->
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Media">
+                <param name="ios-package" value="CDVSound" />
+            </feature>
+        </config-file>
+        <header-file src="src/ios/CDVSound.h" />
+        <source-file src="src/ios/CDVSound.m" />
+        <preference name="MICROPHONE_USAGE_DESCRIPTION" default=" " />
+        <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
+            <string>$MICROPHONE_USAGE_DESCRIPTION</string>
+        </config-file>
+    </platform>
 
     <!-- blackberry10 -->
     <platform name="blackberry10">


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Add mandatory iOS 10 privacy description for microphone usage
Also formats plugin.xml better and fix some errors on examples

### What testing has been done on this change?
tested on iOS 10 device

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

