### PR TITLE
CB-12146: (android) Adds support for "playAudioWhenScreenIsLocked" already used in iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,16 @@ Starts or resumes playing an audio file.
 media.play();
 ```
 
+### Parameters
+
+- __playAudioWhenScreenIsLocked__: Pass in this option to the `play`
+  method to specify whether you want to allow playback when the screen
+  is locked.  If set to `true` (the default value), the state of the
+  hardware mute button is ignored, e.g.:
+
+        var myMedia = new Media("http://audio.ibeat.org/content/p1rj1s/p1rj1s_-_rockGuitar.mp3")
+        myMedia.play({ playAudioWhenScreenIsLocked : false })
+
 ### Quick Example
 
 ```js
@@ -355,20 +365,16 @@ function playAudio(url) {
         var myMedia = new Media("http://audio.ibeat.org/content/p1rj1s/p1rj1s_-_rockGuitar.mp3")
         myMedia.play({ numberOfLoops: 2 })
 
-- __playAudioWhenScreenIsLocked__: Pass in this option to the `play`
-  method to specify whether you want to allow playback when the screen
-  is locked.  If set to `true` (the default value), the state of the
-  hardware mute button is ignored, e.g.:
-
-        var myMedia = new Media("http://audio.ibeat.org/content/p1rj1s/p1rj1s_-_rockGuitar.mp3")
-        myMedia.play({ playAudioWhenScreenIsLocked : false })
-
 - __order of file search__: When only a file name or simple path is
   provided, iOS searches in the `www` directory for the file, then in
   the application's `documents/tmp` directory:
 
         var myMedia = new Media("audio/beer.mp3")
         myMedia.play()  // first looks for file in www/audio/beer.mp3 then in <application>/documents/tmp/audio/beer.mp3
+
+### Windows Quirks
+
+- __playAudioWhenScreenIsLocked__: not supported.
 
 ## media.release
 

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -93,17 +93,29 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     private boolean prepareOnly = true;     // playback after file prepare flag
     private int seekOnPrepared = 0;     // seek to this location once media is prepared
 
-    /**
+    private boolean playAudioWhenScreenIsLocked = true; // If set to false the playback will be paused when app is paused
+    
+    public boolean isPlayAudioWhenScreenIsLocked() {
+		return playAudioWhenScreenIsLocked;
+	}
+
+	public void setPlayAudioWhenScreenIsLocked(boolean playAudioWhenScreenIsLocked) {
+		this.playAudioWhenScreenIsLocked = playAudioWhenScreenIsLocked;
+	}
+
+	/**
      * Constructor.
      *
      * @param handler           The audio handler object
      * @param id                The id of this audio player
      */
-    public AudioPlayer(AudioHandler handler, String id, String file) {
+    public AudioPlayer(AudioHandler handler, String id, String file, boolean playAudioWhenScreenIsLocked) {
         this.handler = handler;
         this.id = id;
         this.audioFile = file;
         this.tempFiles = new LinkedList<String>();
+
+        this.playAudioWhenScreenIsLocked = playAudioWhenScreenIsLocked;
     }
 
     private String generateTempFile() {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Handle sound pausing and resuming on events like onPause, AudioFocus and if the phone rings.
    
In this patch we handle the playAudioWhenScreenIsLocked option and we must handle three cases independently
 * on Pause and onResume - pause depening if playAudioWhenScreenIsLocked is set for this audio player
 * AudioFocus (refactored)
 * phone ringing (refactored)

We have three general states:
 * No paused sounds
 * All sounds paused
 * Sounds only paused if the playAudioWhenScreenIsLocked flag is set to false

### What testing has been done on this change?
Manual testing on Nexus 5

### Checklist
- [x] JIRA https://issues.apache.org/jira/browse/CB-12146
- [ ] Open: automated test coverage as appropriate for this change.
