### PR TITLE
CB-12157: (android): Fix java.lang.NullPointerException on resumeAllGainedFocus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,10 @@ Thumbs.db
 
 node_modules
 
-
+#eclipse
+bin
+.project
+.classpath
 
 
 

--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -411,7 +411,7 @@ public class AudioHandler extends CordovaPlugin {
 
     public void resumeAllGainedFocus() {
         for (AudioPlayer audio : this.pausedForFocus) {
-            audio.startPlaying(null);
+            audio.resumePlaying();
         }
         this.pausedForFocus.clear();
     }

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -354,6 +354,13 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     }
 
     /**
+     * Resume playing.
+     */
+    public void resumePlaying() {
+    	this.startPlaying(this.audioFile);
+    }
+
+    /**
      * Callback to be invoked when playback of a media source has completed.
      *
      * @param player           The MediaPlayer that reached the end of the file
@@ -582,7 +589,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                     //if we are readying the same file
                     if (this.audioFile.compareTo(file) == 0) {
                         //maybe it was recording?
-                        if(this.recorder!=null && player==null) {
+                        if (player == null) {
                             this.player = new MediaPlayer();
                             this.player.setOnErrorListener(this);
                             this.prepareOnly = false;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
- Android


### What does this PR do?
fix issue in AudioPlayer when file is null:

```java
if (this.audioFile.compareTo(file) == 0) {
```

```java
11-16 16:13:11.071 E/AndroidRuntime(30650): FATAL EXCEPTION: JavaBridge
11-16 16:13:11.071 E/AndroidRuntime(30650): java.lang.NullPointerException
11-16 16:13:11.071 E/AndroidRuntime(30650):     at org.apache.cordova.media.AudioPlayer.readyPlayer(AudioPlayer.java:583)
11-16 16:13:11.071 E/AndroidRuntime(30650):     at org.apache.cordova.media.AudioPlayer.startPlaying(AudioPlayer.java:299)
11-16 16:13:11.071 E/AndroidRuntime(30650):     at org.apache.cordova.media.AudioHandler.resumeAllGainedFocus(AudioHandler.java:414)
11-16 16:13:11.071 E/AndroidRuntime(30650):     at org.apache.cordova.media.AudioHandler$1.onAudioFocusChange(AudioHandler.java:431)
11-16 16:13:11.071 E/AndroidRuntime(30650):     at android.media.AudioManager$FocusEventHandlerDelegate$1.handleMessage(AudioManager.java:2044)
11-16 16:13:11.071 E/AndroidRuntime(30650):     at android.os.Handler.dispatchMessage(Handler.java:102)
11-16 16:13:11.071 E/AndroidRuntime(30650):     at android.os.Looper.loop(Looper.java:136)
11-16 16:13:11.071 E/AndroidRuntime(30650):     at android.os.HandlerThread.run(HandlerThread.java:61)
```
This happens in AudioHandler in resumeAllGainedFocus. startPlaying was called with null.

### What testing has been done on this change?
Caused resumeAllGainedFocus was called and resumePlaying is called.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

