### PR TITLE
CB-12319: (Android&iOS) Fix bug that recorded audio files of Android cannot be played in iOS with the html <audio> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ function recordAudio() {
 
 ### Android Quirks
 
-- Android devices record audio in Adaptive Multi-Rate format. The specified file should end with a _.amr_ extension.
+- Android devices record audio in AAC ADTS file format. The specified file should end with a _.aac_ extension.
 - The hardware volume controls are wired up to the media volume while any Media objects are alive. Once the last created Media object has `release()` called on it, the volume controls revert to their default behaviour. The controls are also reset on page navigation, as this releases all Media objects.
 
 ### iOS Quirks

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,6 +30,10 @@ id="cordova-plugin-media"
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-media.git</repo>
     <issue>https://issues.apache.org/jira/browse/CB/component/12320647</issue>
 
+    <engines>
+        <engine name="cordova-android" version=">=6.1.0" />
+    </engines>
+  
     <dependency id="cordova-plugin-file" version="^4.0.0" />
     <dependency id="cordova-plugin-compat" version="^1.0.0" />
 

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -151,8 +151,8 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             this.audioFile = file;
             this.recorder = new MediaRecorder();
             this.recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
-            this.recorder.setOutputFormat(MediaRecorder.OutputFormat.RAW_AMR); // THREE_GPP);
-            this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB); //AMR_NB);
+            this.recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS); // RAW_AMR);
+            this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC); //AMR_NB);
             this.tempFile = generateTempFile();
             this.recorder.setOutputFile(this.tempFile);
             try {


### PR DESCRIPTION
Make the output file of Android an acc file in order to play the audio file with the html <audio> tag in iOS:
1. change OutputFormat from RAW_AMR to AAC_ADTS
2. change OutputFormat from AMR_NB to AAC

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
