### PR TITLE
(android) Fix NullPointerException in AudioPlayer.readyPlayer

### DIFF
--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -583,7 +583,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                     return true;
                 case MEDIA_STOPPED:
                     //if we are readying the same file
-                    if (this.audioFile.compareTo(file) == 0) {
+                    if (file != null && this.audioFile.compareTo(file) == 0) {
                         //maybe it was recording?
                         if(this.recorder!=null && player==null) {
                             this.player = new MediaPlayer();

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -583,7 +583,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                     return true;
                 case MEDIA_STOPPED:
                     //if we are readying the same file
-                    if (file != null && this.audioFile.compareTo(file) == 0) {
+                    if (file!=null && this.audioFile.compareTo(file) == 0) {
                         //maybe it was recording?
                         if(this.recorder!=null && player==null) {
                             this.player = new MediaPlayer();


### PR DESCRIPTION
### Platforms affected

Android

### What does this PR do?

Fixes null pointer exception with following path:

#0. Crashed: JavaBridge: 0 0 0x0000000000000000
       at java.lang.String.compareTo(String.java)
       at org.apache.cordova.media.AudioPlayer.readyPlayer(AudioPlayer.java:583)
       at org.apache.cordova.media.AudioPlayer.startPlaying(AudioPlayer.java:299)
       at org.apache.cordova.media.AudioHandler.resumeAllGainedFocus(AudioHandler.java:414)
       at org.apache.cordova.media.AudioHandler$1.onAudioFocusChange(AudioHandler.java:431)

Mechanism: resumeAllGainedFocus() calls startPlaying(null) and null value is not handled properly in readyPlayer().

### What testing has been done on this change?

Only crash scenario has been tested (performs only extra validation)

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.