### PR TITLE
CB-12542 - Can't record to a wav file

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -24,7 +24,7 @@
 #define HTTP_SCHEME_PREFIX @"http://"
 #define HTTPS_SCHEME_PREFIX @"https://"
 #define CDVFILE_PREFIX @"cdvfile://"
-#define RECORDING_WAV @"wav"
+#define RECORDING_WAV @"m4a"
 
 @implementation CDVSound
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -792,7 +792,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     //Ensures that file doesn't exist to test CB-11380
     function getRecordSrc() {
         var noop = function () {};
-        recordSrc = "cdvfile://localhost/temporary/iOSRecording.wav";
+        recordSrc = "cdvfile://localhost/temporary/iOSRecording.m4a";
         window.resolveLocalFileSystemURL(recordSrc, function (file) {
             file.remove(function() {
                 console.log("Successfully removed " + recordSrc);


### PR DESCRIPTION
Thanks to Leo Schubert for this patch (see JIRA issue).

### Platforms affected

iOS

### What does this PR do?

Change the file extension of the file being recorded to .m4a  (AAC)

### What testing has been done on this change?

cordova-paramedic local test on iOS (flaky). I plan to let the CI run the device tests.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
