### PR TITLE
CB-12146 (android) Adding playAudioWhenScreenIsLocked for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,18 @@ function playAudio(url) {
 }
 ```
 
+### Parameters
+
+- __playAudioWhenScreenIsLocked__: Pass in this option to the `play`
+  method to specify whether you want to allow playback when the screen
+  is locked or the app is in Background(Android). The standard value is true.
+   e.g.:
+
+        var myMedia = new Media("http://audio.ibeat.org/content/p1rj1s/p1rj1s_-_rockGuitar.mp3");
+        myMedia.play({ playAudioWhenScreenIsLocked : true });
+        myMedia.setVolume('1.0');
+
+
 ### iOS Quirks
 
 - __numberOfLoops__: Pass this option to the `play` method to specify
@@ -355,15 +367,8 @@ function playAudio(url) {
         var myMedia = new Media("http://audio.ibeat.org/content/p1rj1s/p1rj1s_-_rockGuitar.mp3")
         myMedia.play({ numberOfLoops: 2 })
 
-- __playAudioWhenScreenIsLocked__: Pass in this option to the `play`
-  method to specify whether you want to allow playback when the screen
-  is locked.  If set to `true` (the default value), the state of the
-  hardware mute button is ignored, e.g.:
-
-        var myMedia = new Media("http://audio.ibeat.org/content/p1rj1s/p1rj1s_-_rockGuitar.mp3");
-        myMedia.play({ playAudioWhenScreenIsLocked : true });
-        myMedia.setVolume('1.0');
-
+- __playAudioWhenScreenIsLocked__: 
+ If set to `true`, the state of the hardware mute button is ignored.
 > Note: To allow playback with the screen locked or background audio you have to add `audio` to `UIBackgroundModes` in the `info.plist` file. See [Apple documentation](https://developer.apple.com/library/content/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/BackgroundExecution/BackgroundExecution.html#//apple_ref/doc/uid/TP40007072-CH4-SW23). Also note that the audio has to be started before going to background.
 
 - __order of file search__: When only a file name or simple path is

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -18,6 +18,18 @@
 */
 package org.apache.cordova.media;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.LinkedList;
+
+import org.apache.cordova.LOG;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnCompletionListener;
@@ -25,19 +37,6 @@ import android.media.MediaPlayer.OnErrorListener;
 import android.media.MediaPlayer.OnPreparedListener;
 import android.media.MediaRecorder;
 import android.os.Environment;
-
-import org.apache.cordova.LOG;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.IOException;
-import java.util.LinkedList;
 
 /**
  * This class implements the audio playback and recording capabilities used by Cordova.
@@ -93,17 +92,29 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     private boolean prepareOnly = true;     // playback after file prepare flag
     private int seekOnPrepared = 0;     // seek to this location once media is prepared
 
-    /**
+    private boolean playAudioWhenScreenIsLocked = true; // If set to false the playback will be paused when app is paused
+    
+    public boolean isPlayAudioWhenScreenIsLocked() {
+		return playAudioWhenScreenIsLocked;
+	}
+
+	public void setPlayAudioWhenScreenIsLocked(boolean playAudioWhenScreenIsLocked) {
+		this.playAudioWhenScreenIsLocked = playAudioWhenScreenIsLocked;
+	}
+
+	/**
      * Constructor.
      *
      * @param handler           The audio handler object
      * @param id                The id of this audio player
      */
-    public AudioPlayer(AudioHandler handler, String id, String file) {
+    public AudioPlayer(AudioHandler handler, String id, String file, boolean playAudioWhenScreenIsLocked) {
         this.handler = handler;
         this.id = id;
         this.audioFile = file;
         this.tempFiles = new LinkedList<String>();
+
+        this.playAudioWhenScreenIsLocked = playAudioWhenScreenIsLocked;
     }
 
     private String generateTempFile() {


### PR DESCRIPTION
When loosing focus of the app in android (onPause()) the audio playback is paused when playAudioWhenScreenIsLocked is set to false.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Adds the playAudioWhenScreenIsLocked flag to the Android version. This makes it possible to selectively keep audios playing, when onPause is called.

### What testing has been done on this change?
Manual testing on Android N

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
