### PR TITLE
CB-7684

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -112,7 +112,7 @@ id="cordova-plugin-media"
         <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
             <string>$MICROPHONE_USAGE_DESCRIPTION</string>
         </config-file>
-        <preference name="KeepAVAudioSessionAlwaysActive" default="NO" />
+        <preference name="KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" default="NO" />
     </platform>
 
     <!-- blackberry10 -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -113,6 +113,11 @@ id="cordova-plugin-media"
             <string>$MICROPHONE_USAGE_DESCRIPTION</string>
         </config-file>
         <preference name="KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" default="NO" />
+        <config-file target="config.xml" parent="/*">
+            <preference
+              name="KeepAVAudioSessionAlwaysActive"
+              value="$KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" />
+        </config-file>
     </platform>
 
     <!-- blackberry10 -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -71,14 +71,14 @@ id="cordova-plugin-media"
                 <param name="ios-package" value="CDVSound" />
             </feature>
         </config-file>
-        <header-file src="src/ios/CDVSound.h" />
-        <source-file src="src/ios/CDVSound.m" />
         <preference name="KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" default="NO" />
         <config-file target="config.xml" parent="/*">
             <preference
               name="KeepAVAudioSessionAlwaysActive"
               value="$KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" />
         </config-file>
+        <header-file src="src/ios/CDVSound.h" />
+        <source-file src="src/ios/CDVSound.m" />
     </platform>
 
     <!-- windows -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -103,6 +103,7 @@ id="cordova-plugin-media"
         <config-file target="config.xml" parent="/*">
             <feature name="Media">
                 <param name="ios-package" value="CDVSound" />
+                <param name="onload" value="true"/>
             </feature>
         </config-file>
         <header-file src="src/ios/CDVSound.h" />
@@ -111,6 +112,7 @@ id="cordova-plugin-media"
         <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
             <string>$MICROPHONE_USAGE_DESCRIPTION</string>
         </config-file>
+        <preference name="KeepAVAudioSessionAlwaysActive" default="NO" />
     </platform>
 
     <!-- blackberry10 -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -66,13 +66,11 @@ id="cordova-plugin-media"
 
     <!-- ios -->
     <platform name="ios">
+      <preference name="KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" default="NO" />
         <config-file target="config.xml" parent="/*">
             <feature name="Media">
                 <param name="ios-package" value="CDVSound" />
             </feature>
-        </config-file>
-        <preference name="KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" default="NO" />
-        <config-file target="config.xml" parent="/*">
             <preference
               name="KeepAVAudioSessionAlwaysActive"
               value="$KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
 id="cordova-plugin-media"
-    version="3.0.1">
+    version="5.0.2-dev">
 
     <name>Media</name>
     <description>Cordova Media Plugin</description>
@@ -31,11 +31,10 @@ id="cordova-plugin-media"
     <issue>https://issues.apache.org/jira/browse/CB/component/12320647</issue>
 
     <engines>
-        <engine name="cordova-android" version=">=6.1.0" />
+        <engine name="cordova-android" version=">=6.3.0" />
     </engines>
 
-    <dependency id="cordova-plugin-file" version="^4.0.0" />
-    <dependency id="cordova-plugin-compat" version="^1.0.0" />
+    <dependency id="cordova-plugin-file" version="^6.0.0" />
 
     <js-module src="www/MediaError.js" name="MediaError">
         <clobbers target="window.MediaError" />
@@ -65,112 +64,20 @@ id="cordova-plugin-media"
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/media" />
     </platform>
 
-     <!-- amazon-fireos -->
-    <platform name="amazon-fireos">
-        <config-file target="res/xml/config.xml" parent="/*">
-            <feature name="Media" >
-                <param name="android-package" value="org.apache.cordova.media.AudioHandler"/>
-            </feature>
-        </config-file>
-
-        <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.RECORD_AUDIO" />
-            <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-        </config-file>
-
-        <source-file src="src/android/AudioHandler.java" target-dir="src/org/apache/cordova/media" />
-        <source-file src="src/android/AudioPlayer.java" target-dir="src/org/apache/cordova/media" />
-        <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/media" />
-    </platform>
-
-
-    <!-- ubuntu -->
-    <platform name="ubuntu">
-        <config-file target="config.xml" parent="/*">
-            <feature name="Media">
-                <param policy_group="microphone" policy_version="1" />
-                <param policy_group="video" policy_version="1" />
-            </feature>
-        </config-file>
-        <header-file src="src/ubuntu/media.h" />
-        <source-file src="src/ubuntu/media.cpp" />
-    </platform>
-
     <!-- ios -->
     <platform name="ios">
         <config-file target="config.xml" parent="/*">
             <feature name="Media">
                 <param name="ios-package" value="CDVSound" />
-                <param name="onload" value="true"/>
             </feature>
         </config-file>
         <header-file src="src/ios/CDVSound.h" />
         <source-file src="src/ios/CDVSound.m" />
-        <preference name="MICROPHONE_USAGE_DESCRIPTION" default=" " />
-        <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
-            <string>$MICROPHONE_USAGE_DESCRIPTION</string>
-        </config-file>
         <preference name="KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" default="NO" />
         <config-file target="config.xml" parent="/*">
             <preference
               name="KeepAVAudioSessionAlwaysActive"
               value="$KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" />
-        </config-file>
-    </platform>
-
-    <!-- blackberry10 -->
-    <platform name="blackberry10">
-        <source-file src="src/blackberry10/index.js" target-dir="Media" />
-        <config-file target="www/config.xml" parent="/widget">
-            <feature name="Media" value="Media"/>
-        </config-file>
-    </platform>
-
-    <!-- wp7 -->
-    <platform name="wp7">
-        <config-file target="config.xml" parent="/*">
-            <feature name="Media">
-                <param name="wp-package" value="Media"/>
-            </feature>
-        </config-file>
-
-        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
-            <Capability Name="ID_CAP_MEDIALIB"/>
-            <Capability Name="ID_CAP_MICROPHONE"/>
-        </config-file>
-
-        <source-file src="src/wp/Media.cs" />
-        <source-file src="src/wp/AudioPlayer.cs" />
-    </platform>
-
-    <!-- wp8 -->
-    <platform name="wp8">
-        <config-file target="config.xml" parent="/*">
-            <feature name="Media">
-                <param name="wp-package" value="Media"/>
-            </feature>
-        </config-file>
-
-        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
-            <Capability Name="ID_CAP_MEDIALIB_AUDIO"/>
-            <Capability Name="ID_CAP_MEDIALIB_PLAYBACK"/>
-            <Capability Name="ID_CAP_MICROPHONE"/>
-        </config-file>
-
-        <source-file src="src/wp/Media.cs" />
-        <source-file src="src/wp/AudioPlayer.cs" />
-    </platform>
-
-    <!-- windows8 -->
-    <platform name="windows8">
-        <js-module src="src/windows/MediaProxy.js" name="MediaProxy">
-            <runs />
-        </js-module>
-
-        <config-file target="package.appxmanifest" parent="/Package/Capabilities">
-            <DeviceCapability Name="microphone" />
         </config-file>
     </platform>
 
@@ -183,13 +90,6 @@ id="cordova-plugin-media"
         <config-file target="package.appxmanifest" parent="/Package/Capabilities">
             <DeviceCapability Name="microphone" />
         </config-file>
-    </platform>
-
-    <!-- tizen -->
-    <platform name="tizen">
-        <js-module src="src/tizen/MediaProxy.js" name="MediaProxy">
-            <runs/>
-        </js-module>
     </platform>
 
     <!-- browser -->

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -421,7 +421,7 @@
                 [audioFile.player play];
             } */
             // error creating the session or player
-            [self onStatus:MEDIA_ERROR mediaId:mediaId 
+            [self onStatus:MEDIA_ERROR mediaId:mediaId
               param:[self createMediaErrorWithCode:MEDIA_ERR_NONE_SUPPORTED message:nil]];
         }
     }
@@ -795,18 +795,18 @@
         [self onStatus:MEDIA_ERROR mediaId:mediaId param:
             [self createMediaErrorWithCode:MEDIA_ERR_DECODE message:nil]];
     }
-    if (self.avSession) {
-        [self.avSession setActive:NO error:nil];
-    }
+    // if (self.avSession) {
+    //     [self.avSession setActive:NO error:nil];
+    // }
 }
 
 -(void)itemDidFinishPlaying:(NSNotification *) notification {
     // Will be called when AVPlayer finishes playing playerItem
     NSString* mediaId = self.currMediaId;
 
-    if (self.avSession) {
-        [self.avSession setActive:NO error:nil];
-    }
+    // if (self.avSession) {
+    //     [self.avSession setActive:NO error:nil];
+    // }
     [self onStatus:MEDIA_STATE mediaId:mediaId param:@(MEDIA_STOPPED)];
 }
 
@@ -917,7 +917,7 @@
         status[@"msgType"] = @(what);
         //in the error case contains a dict with "code" and "message"
         //otherwise a NSNumber
-        status[@"value"] = param; 
+        status[@"value"] = param;
         status[@"id"] = mediaId;
         NSMutableDictionary* dict=[NSMutableDictionary dictionary];
         dict[@"action"] = @"status";
@@ -931,7 +931,7 @@
             param=[[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
         }
         NSString* jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);",
-              @"cordova.require('cordova-plugin-media.Media').onStatus", 
+              @"cordova.require('cordova-plugin-media.Media').onStatus",
               mediaId, (int)what, param];
         [self.commandDelegate evalJs:jsString];
     }

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -34,7 +34,7 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 -(void) pluginInitialize
 {
     NSDictionary* settings = self.commandDelegate.settings;
-    keepAvAudioSessionAlwaysActive = [[settings objectForKey:[@"KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" lowercaseString]] boolValue];
+    keepAvAudioSessionAlwaysActive = [[settings objectForKey:[@"KeepAVAudioSessionAlwaysActive" lowercaseString]] boolValue];
     if (keepAvAudioSessionAlwaysActive) {
         [self hasAudioSession];
     }

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -34,7 +34,7 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 -(void) pluginInitialize
 {
     NSDictionary* settings = self.commandDelegate.settings;
-    keepAvAudioSessionAlwaysActive = [[settings objectForKey:[@"KeepAVAudioSessionAlwaysActive" lowercaseString]] boolValue];
+    keepAvAudioSessionAlwaysActive = [[settings objectForKey:[@"KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE" lowercaseString]] boolValue];
     if (keepAvAudioSessionAlwaysActive) {
         [self hasAudioSession];
     }

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -36,7 +36,12 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
     NSDictionary* settings = self.commandDelegate.settings;
     keepAvAudioSessionAlwaysActive = [[settings objectForKey:[@"KeepAVAudioSessionAlwaysActive" lowercaseString]] boolValue];
     if (keepAvAudioSessionAlwaysActive) {
-        [self hasAudioSession];
+        if ([self hasAudioSession]) {
+            NSError* error = nil;
+            if(![self.avSession setActive:YES error:&error]) {
+                NSLog(@"Unable to activate session: %@", [error localizedFailureReason]);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

This PR will add an `isPlayingOrRecording` method that's called before any try to deactivate the AVSession.

### What testing has been done on this change?

This has been tested on 11 apps that are going to updated live.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
