### PR TITLE
fix(ios): Reset default audio session category when release (CB-13243)

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -601,6 +601,7 @@
                 avPlayer = nil;
             }
             if (self.avSession) {
+                [self.avSession setCategory:AVAudioSessionCategorySoloAmbient error:nil];
                 [self.avSession setActive:NO error:nil];
                 self.avSession = nil;
             }


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Fix plugin

### What testing has been done on this change?
After recording and releasing, can play other audio source output.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
