### PR TITLE
CB-13265 Remove ios usage description from media plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,13 +566,19 @@ function recordAudio() {
 
         var myMedia = new Media("documents://beer.mp3")
 
-- Since iOS 10 it's mandatory to add a `NSMicrophoneUsageDescription` entry in the info.plist.
+- Since iOS 10 it's mandatory to provide an usage description in the `info.plist` if trying to access privacy-sensitive data. When the system prompts the user to allow access, this usage description string will displayed as part of the permission dialog box, but if you didn't provide the usage description, the app will crash before showing the dialog. Also, Apple will reject apps that access private data but don't provide an usage description.
 
-`NSMicrophoneUsageDescription` describes the reason that the app accesses the user’s microphone. When the system prompts the user to allow access, this string is displayed as part of the dialog box. To add this entry you can pass the variable `MICROPHONE_USAGE_DESCRIPTION` on plugin install.
+This plugins requires the following usage description:
 
-Example: `cordova plugin add cordova-plugin-media --variable MICROPHONE_USAGE_DESCRIPTION="your usage message"`
+* `NSMicrophoneUsageDescription` describes the reason that the app accesses the user's microphone. 
 
-If you don't pass the variable, the plugin will add an empty string as value.
+To add this entry into the `info.plist`, you can use the `edit-config` tag in the `config.xml` like this:
+
+```
+<edit-config target="NSMicrophoneUsageDescription" file="*-Info.plist" mode="merge">
+    <string>need microphone access to record sounds</string>
+</edit-config>
+```
 
 ### Windows Quirks
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -106,10 +106,6 @@ id="cordova-plugin-media"
         </config-file>
         <header-file src="src/ios/CDVSound.h" />
         <source-file src="src/ios/CDVSound.m" />
-        <preference name="MICROPHONE_USAGE_DESCRIPTION" default=" " />
-        <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
-            <string>$MICROPHONE_USAGE_DESCRIPTION</string>
-        </config-file>
     </platform>
 
     <!-- blackberry10 -->


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
ios

### What does this PR do?
Removes the MICROPHONE_USAGE_DESCRIPTION preference and documents how to use edit-config to do the same

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
