### PR TITLE
CB-13445: (ios) Streaming media can take up to 8-10 seconds to start - fixed!

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -249,6 +249,9 @@
             // Pass the AVPlayerItem to a new player
             avPlayer = [[AVPlayer alloc] initWithPlayerItem:playerItem];
 
+            //Avoid excessive buffering so streaming media can play instantly on iOS
+            avPlayer.automaticallyWaitsToMinimizeStalling = NO;
+
             //avPlayer = [[AVPlayer alloc] initWithURL:resourceUrl];
         }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
iOS streaming media can take up to 8-10 seconds to start. This fix allows streaming media to start right away. Caveat: on a slow internet connection there might be pauses for buffering (depends on size+length of media).

### What testing has been done on this change?
Tested on Ionic 1 & Ionic 2/3 using Cordova.
Tested on iPhone 5s, iPhone6 Plus, iPhone X (simulator)

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
