### PR TITLE
CB-13502: (android) Implementation of setRate method for Android Marshmallow and later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ addons:
     secure: M4uBGUMbanDtCBrNktJhEwNSLL0UsOV3IoINqW3GRupX7Mr13MBZzsORm4HVbdbPxQ6Bf2LhyJ/fabQRsOoJrCokgWwfKkigztQcMFeLNao9liBRA6kuQOh5/rdfoULpu96GvlYzB4ddgSBSSGQW3DesaKC/BpTXnvQ4OnXo5e4=
 env:
   global:
-  - SAUCE_USERNAME=snay
+  - SAUCE_USERNAME=jh3141
   - TRAVIS_NODE_VERSION="4.2"
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -23,36 +23,25 @@ description: Record and play audio on the device.
 
 |AppVeyor|Travis CI|
 |:-:|:-:|
-|[![Build status](https://ci.appveyor.com/api/projects/status/github/apache/cordova-plugin-media?branch=master)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/cordova-plugin-media)|[![Build Status](https://travis-ci.org/apache/cordova-plugin-media.svg?branch=master)](https://travis-ci.org/apache/cordova-plugin-media)|
+|[![Build status](https://ci.appveyor.com/api/projects/status/github/apache/cordova-plugin-media?branch=master)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/cordova-plugin-media)|[![Build Status](https://travis-ci.org/jh3141/cordova-plugin-media.svg?branch=master)](https://travis-ci.org/jh3141/cordova-plugin-media)|
 
 # cordova-plugin-media
 
 
-This plugin provides the ability to record and play back audio files on a device.
+This is a forked version of the cordova-plugin-media plugin, which provides the ability to record
+and play back audio files on a device.  This fork adds the following changes:
 
-__NOTE__: The current implementation does not adhere to a W3C
-specification for media capture, and is provided for convenience only.
-A future implementation will adhere to the latest W3C specification
-and may deprecate the current APIs.
+* Support the `setRate` API under Android
+* Fix broken tests
 
-This plugin defines a global `Media` Constructor.
-
-Although in the global scope, it is not available until after the `deviceready` event.
-
-```js
-document.addEventListener("deviceready", onDeviceReady, false);
-function onDeviceReady() {
-    console.log(Media);
-}
-```
-
-Report issues with this plugin on the [Apache Cordova issue tracker](https://issues.apache.org/jira/issues/?jql=project%20%3D%20CB%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20%22cordova-plugin-media%22%20ORDER%20BY%20priority%20DESC%2C%20summary%20ASC%2C%20updatedDate%20DESC)
-
+Additional updates are planned for better handling of background playing, and supporting background
+application use.  If they aren't available here yet, there may be development versions in branches
+that haven't been merged yet; have a look at those if you're interested.
 
 ## Installation
 
 ```bash
-cordova plugin add cordova-plugin-media
+cordova plugin add https://github.com/jh3141/cordova-plugin-media
 ```
 
 ## Supported Platforms
@@ -322,8 +311,12 @@ function recordAudio() {
 Starts or resumes playing an audio file.
 
 ```js
-media.play();
+media.play(options);
 ```
+
+* Options specifies optional settings for player behaviour, and may be omitted if
+  the defaults are to be used.  See the platform-specific descriptions below for
+  available options.
 
 ### Quick Example
 

--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -178,6 +178,12 @@ public class AudioHandler extends CordovaPlugin {
             float f = this.getCurrentAmplitudeAudio(args.getString(0));
             callbackContext.sendPluginResult(new PluginResult(status, f));
             return true;
+        } else if (action.equals("setRate")) {
+            try {
+                this.setRate(args.getString(0), Float.parseFloat(args.getString(1)));
+            } catch (NumberFormatException nfe) {
+                //no-op
+            }
         }
         else { // Unrecognized action.
             return false;
@@ -484,6 +490,23 @@ public class AudioHandler extends CordovaPlugin {
             audio.setVolume(volume);
         } else {
           LOG.e(TAG3,"Unknown Audio Player " + id);
+        }
+    }
+
+    /**
+     * Set the playback rate for an audio player
+     *
+     * @param id				The id of the audio player
+     * @param rate              Playback rate (where 1.0 is normal speed)
+     */
+    public void setRate(String id, float rate) {
+        String TAG4 = "AudioHandler.setRate(): Error : ";
+
+        AudioPlayer audio = this.players.get(id);
+        if (audio != null) {
+            audio.setRate(rate);
+        } else {
+          LOG.e(TAG4,"Unknown Audio Player " + id);
         }
     }
 

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -542,6 +542,24 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     }
 
     /**
+     * Set the playback rate for the player (ignored on API < 23)
+     *
+     * @param volume
+     */
+    public void setRate(float rate) {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
+            LOG.d(LOG_TAG, "AudioPlayer Warning: Request to set playback rate not supported on current OS version");
+            return;
+        }
+        if (this.player != null) {
+            this.player.setPlaybackParams (this.player.getPlaybackParams().setSpeed(rate));
+        } else {
+            LOG.d(LOG_TAG, "AudioPlayer Error: Cannot set playback rate until the audio file is initialized.");
+            sendErrorStatus(MEDIA_ERR_NONE_ACTIVE);
+        }
+    }
+
+    /**
      * attempts to put the player in play mode
      * @return true if in playmode, false otherwise
      */

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -92,6 +92,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     private MediaPlayer player = null;      // Audio player object
     private boolean prepareOnly = true;     // playback after file prepare flag
     private int seekOnPrepared = 0;     // seek to this location once media is prepared
+    private float setRateOnPrepared = -1;
 
     /**
      * Constructor.
@@ -446,6 +447,9 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         this.player.setOnCompletionListener(this);
         // seek to any location received while not prepared
         this.seekToPlaying(this.seekOnPrepared);
+        // apply any playback rate received while not prepared
+        if (setRateOnPrepared >= 0)
+            this.player.setPlaybackParams (this.player.getPlaybackParams().setSpeed(setRateOnPrepared));
         // If start playing after prepared
         if (!this.prepareOnly) {
             this.player.start();
@@ -554,8 +558,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         if (this.player != null) {
             this.player.setPlaybackParams (this.player.getPlaybackParams().setSpeed(rate));
         } else {
-            LOG.d(LOG_TAG, "AudioPlayer Error: Cannot set playback rate until the audio file is initialized.");
-            sendErrorStatus(MEDIA_ERR_NONE_ACTIVE);
+            setRateOnPrepared = rate;
         }
     }
 

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -93,6 +93,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     private boolean prepareOnly = true;     // playback after file prepare flag
     private int seekOnPrepared = 0;     // seek to this location once media is prepared
     private float setRateOnPrepared = -1;
+    private boolean ignoreFocusLost = false;
 
     /**
      * Constructor.
@@ -739,5 +740,23 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             }
         }
         return 0;
+    }
+
+    /**
+     * Sets the flag controlling whether this player should be paused whenever
+     * audio focus is lost.  Default false => pause is performed.
+     */
+    public void setIgnoreFocusLost (boolean ignoreFocusLost)
+    {
+        this.ignoreFocusLost = ignoreFocusLost;
+    }
+
+    /**
+     * Gets the flag controlling whether this player should be paused whenever
+     * audio focus is lost.  Default false => pause is performed.
+     */
+    public boolean getIgnoreLostFocus ()
+    {
+        return ignoreFocusLost;
     }
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -27,7 +27,7 @@
 var ACTUAL_PLAYBACK_TEST_TIMEOUT = 2 * 60 * 1000;
 
 var WEB_MP3_FILE = 'https://cordova.apache.org/downloads/BlueZedEx.mp3';
-var WEB_MP3_STREAM = 'http://c22033-l.i.core.cdn.streamfarm.net/22033mdr/live/3087mdr_figaro/ch_classic_128.mp3';
+var WEB_MP3_STREAM = 'http://forever.fm/all.mp3';
 
 var isWindows = cordova.platformId === 'windows8' || cordova.platformId === 'windows';
 var isBrowser = cordova.platformId === 'browser';

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -36,6 +36,14 @@ var isBrowser = cordova.platformId === 'browser';
 // the case for Sauce Labs emulators - see CB-11430)
 var isAudioSupported = isWindows ? !!Windows.Media.Devices.MediaDevice.getDefaultAudioRenderId(Windows.Media.Devices.AudioDeviceRole.default) :
     cordova.platformId === 'ios' ? !window.SAUCELABS_ENV : true;
+// Detect OS version when running on Android
+var androidVersion = null;
+if (cordova.platformId === 'android') {
+    var ua = navigator.userAgent;
+    var androidStart = ua.indexOf('Android ');
+    var versionString = ua.substring(androidStart + 8, ua.indexOf(';', androidStart));
+    androidVersion = versionString.split(".").map(function(x) { return x/1; });
+}
 
 exports.defineAutoTests = function () {
     var failed = function (done, msg, context) {
@@ -376,7 +384,9 @@ exports.defineAutoTests = function () {
         });
 
         it("media.spec.24 playback rate should be set properly using setRate", function (done) {
-            if (cordova.platformId !== 'ios') {
+            if (cordova.platformId !== 'ios' &&
+                (cordova.platformId !== 'android' || androidVersion[0] <= 6))
+            {
                 expect(true).toFailWithMessage('Platform does not supported this feature');
                 pending();
             }

--- a/www/Media.js
+++ b/www/Media.js
@@ -170,7 +170,7 @@ Media.prototype.setVolume = function(volume) {
  * Adjust the playback rate.
  */
 Media.prototype.setRate = function(rate) {
-    if (cordova.platformId === 'ios'){
+    if (cordova.platformId === 'ios' || cordova.platformId === "android"){
         exec(null, null, "Media", "setRate", [this.id, rate]);
     } else {
         console.warn('media.setRate method is currently not supported for', cordova.platformId, 'platform.');


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### What does this PR do?

Support the "setRate" method already supported on iOS for Android Marshmallow devices (API 23) or later.

### What testing has been done on this change?

Tested manually on two devices running different vendor versions of Android 6.0.  
No automated test provided, as I can't see how to restrict the test environment such that the test only runs on Android versions that support the feature.  I imagine somebody more familiar than myself can easily update media.spec.24 to reflect the change.

### Checklist
- [X ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
