### PR TITLE
CB-13690 : (browser) Add src change to method to Media object

### DIFF
--- a/www/browser/Media.js
+++ b/www/browser/Media.js
@@ -108,7 +108,9 @@ Media.MEDIA_STARTING = 1;
 Media.MEDIA_RUNNING = 2;
 Media.MEDIA_PAUSED = 3;
 Media.MEDIA_STOPPED = 4;
-Media.MEDIA_MSG = ["None", "Starting", "Running", "Paused", "Stopped"];
+Media.MEDIA_CHANGED = 5;
+
+Media.MEDIA_MSG = ["None", "Starting", "Running", "Paused", "Stopped", "Changed"];
 
 /**
  * Start or resume playing audio file.
@@ -186,6 +188,21 @@ Media.prototype.getCurrentPosition = function(success, fail) {
 };
 
 /**
+* Change src of audio
+*/
+Media.prototype.changeSrc = function(src){
+    if(this.node){
+        try{
+            this.node.pause();
+            this.node.src = src;
+            Media.onStatus(this.id, Media.MEDIA_STATE, Media.MEDIA_CHANGED);
+        }catch(err){
+            Media.onStatus(this.id, Media.MEDIA_ERROR, err);
+        }
+    }
+}
+
+/**
  * Start recording audio file.
  */
 Media.prototype.startRecord = function() {
@@ -232,6 +249,7 @@ Media.prototype.setRate = function() {
  */
 Media.prototype.release = function() {
     try {
+        this.node.src = "";
         delete this.node;
     } catch (err) {
         Media.onStatus(this.id, Media.MEDIA_ERROR, err);

--- a/www/browser/Media.js
+++ b/www/browser/Media.js
@@ -200,7 +200,7 @@ Media.prototype.changeSrc = function(src){
             Media.onStatus(this.id, Media.MEDIA_ERROR, err);
         }
     }
-}
+};ad
 
 /**
  * Start recording audio file.

--- a/www/browser/Media.js
+++ b/www/browser/Media.js
@@ -200,7 +200,7 @@ Media.prototype.changeSrc = function(src){
             Media.onStatus(this.id, Media.MEDIA_ERROR, err);
         }
     }
-};ad
+};
 
 /**
  * Start recording audio file.


### PR DESCRIPTION
New method to change node src when change audio src, best for playing multiple files/url

Release method now unset node src to empty to cancel ongoing network request before collecting garbage

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
browser

### What does this PR do?
Add audio src change to media object

### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
