### PR TITLE
CB-13774: repair broken recording and playback functionality on Android

### DIFF
--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -151,8 +151,8 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             this.audioFile = file;
             this.recorder = new MediaRecorder();
             this.recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
-            this.recorder.setOutputFormat(MediaRecorder.OutputFormat.DEFAULT);
-            this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT);
+            this.recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS); // RAW_AMR);
+            this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC); //AMR_NB);
             this.tempFile = generateTempFile();
             this.recorder.setOutputFile(this.tempFile);
             try {

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -151,8 +151,8 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             this.audioFile = file;
             this.recorder = new MediaRecorder();
             this.recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
-            this.recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS); // RAW_AMR);
-            this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC); //AMR_NB);
+            this.recorder.setOutputFormat(MediaRecorder.OutputFormat.DEFAULT);
+            this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT);
             this.tempFile = generateTempFile();
             this.recorder.setOutputFile(this.tempFile);
             try {


### PR DESCRIPTION
Revert back to plugins original use of DEFAULT as the audio encode and decoder.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### What does this PR do?

Puts the media encoder/decoder back to DEFAULT

### What testing has been done on this change?

I created a repo that shows the current media plugin failing. Applying the code in this pull request will show it passing.

https://github.com/medsurvey/cordova-media-bug

The problem seems to be that somehow the encoder and decoder are set to different encoding types and are not compatible. Additionally its assuming an encoder is available on the platform and since the interface to the this object does not allow a way to specifying encoding I feel like the default may have been more appropriate. 

### Checklist
*Could not complete these as I don't have access*
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [] Added automated test coverage as appropriate for this change.

