### PR TITLE
CB-12849: checking mediaState in destroy method, and moving file by stream when renameTo failing

### DIFF
--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -130,7 +130,9 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             this.player = null;
         }
         if (this.recorder != null) {
-            this.stopRecording(true);
+            if (this.state != STATE.MEDIA_STOPPED) {
+                this.stopRecording(true);
+            }
             this.recorder.release();
             this.recorder = null;
         }
@@ -197,8 +199,44 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         if (size == 1) {
             String logMsg = "renaming " + this.tempFile + " to " + file;
             LOG.d(LOG_TAG, logMsg);
+
             File f = new File(this.tempFile);
-            if (!f.renameTo(new File(file))) LOG.e(LOG_TAG, "FAILED " + logMsg);
+            if (!f.renameTo(new File(file))) {
+
+                FileOutputStream outputStream = null;
+                File outputFile = null;
+                try {
+                    outputFile = new File(file);
+                    outputStream = new FileOutputStream(outputFile);
+                    FileInputStream inputStream = null;
+                    File inputFile = null;
+                    try {
+                        inputFile = new File(this.tempFile);
+                        LOG.d(LOG_TAG,  "INPUT FILE LENGTH: " + String.valueOf(inputFile.length()) );
+                        inputStream = new FileInputStream(inputFile);
+                        copy(inputStream, outputStream, false);
+                    } catch (Exception e) {
+                        LOG.e(LOG_TAG, e.getLocalizedMessage(), e);
+                   } finally {
+                        if (inputStream != null) try {
+                            inputStream.close();
+                            inputFile.delete();
+                            inputFile = null;
+                        } catch (Exception e) {
+                            LOG.e(LOG_TAG, e.getLocalizedMessage(), e);
+                        }
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    if (outputStream != null) try {
+                        outputStream.close();
+                        LOG.d(LOG_TAG, "OUTPUT FILE LENGTH: " + String.valueOf(outputFile.length()) );
+                    } catch (Exception e) {
+                        LOG.e(LOG_TAG, e.getLocalizedMessage(), e);
+                    }
+                }
+            }
         }
         // more than one file so the user must have pause recording. We'll need to concat files.
         else {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

android

### What does this PR do?

Resolving recording audio issue.

1. File.renameTo method used in AudioPlayer.java can not move file across partitions.
Then  I developed copying the file by using i/o stream when renameTo failing.

2. media.stopRecord() in JS calls stopRecording in Java,
However media.release() in JS also calls stopRecording in Java via destroy method.
The second call of stopRecording overrides the audio file with empty. 
This PR prevents the unnecessary call of stopRecording.

### What testing has been done on this change?

sample code is 
```
var fileName = "test.aac";

var myMedia = {};
var myStatus = null;

function recordMedia(){
    myMedia = new Media(cordova.file.dataDirectory + fileName, function (msg) {
        console.log("Success:", msg);
    }, function (e) {
        console.error("Error:", e);
        myMedia.release();
        myStatus = Media.MEDIA_NONE;
    }, function (status) {
        console.info("Status:", status);
        myStatus = status;
        if (status == Media.MEDIA_STOPPED) {
          myMedia.release();
          myStatus = Media.MEDIA_NONE;
        }
    });

    myMedia.startRecord();
}

function stopMedia () {
    if (myStatus != Media.MEDIA_NONE) {
      if (myStatus != Media.MEDIA_STOPPED) {
        myMedia.stopRecord();
      }
    }
}
```

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
