### PR TITLE
CB-13445 (iOS) Streaming media can take up to 8-10 seconds to start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,12 @@ matrix:
     node_js: '6.14.2'
   - env: PLATFORM=ios-9.3
     os: osx
-    osx_image: xcode7.3
+    osx_image: xcode8.3
     language: node_js
     node_js: '6.14.2'
   - env: PLATFORM=ios-10.0
     os: osx
-    osx_image: xcode7.3
+    osx_image: xcode8.3
     language: node_js
     node_js: '6.14.2'
   - env: PLATFORM=android-4.4

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -265,10 +265,11 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
             // Pass the AVPlayerItem to a new player
             avPlayer = [[AVPlayer alloc] initWithPlayerItem:playerItem];
 
-            //Avoid excessive buffering so streaming media can play instantly on iOS
-            avPlayer.automaticallyWaitsToMinimizeStalling = NO;
-
-            //avPlayer = [[AVPlayer alloc] initWithURL:resourceUrl];
+            // Avoid excessive buffering so streaming media can play instantly on iOS
+            // Removes preplay delay on ios 10+, makes consistent with ios9 behaviour
+            if ([NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10,0,0}]) {
+                avPlayer.automaticallyWaitsToMinimizeStalling = NO;
+            }
         }
 
         self.currMediaId = mediaId;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Calls iOS>=10 API to prevent waiting for the media stream to buffer before playing

### What testing has been done on this change?
tests pass

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
