### PR TITLE
Add error call for stalled_playback (iOS only)

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -833,6 +833,10 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 -(void)itemStalledPlaying:(NSNotification *) notification {
     // Will be called when playback stalls due to buffer empty
     NSLog(@"Stalled playback");
+    NSString* errMsg = @"stalled_playback";
+    NSString* mediaId = self.currMediaId;
+    [self onStatus:MEDIA_ERROR mediaId:mediaId param:
+     [self createAbortError:errMsg]];
 }
 
 - (void)onMemoryWarning


### PR DESCRIPTION
### Platforms affected
- iOS

### What does this PR do?
- Adds an error call for stalled playback on iOS.

### What testing has been done on this change?
Physical device testing on:

- iPhone X (iOS 12)
- iPhone 6 (iOS 11)


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
