### PR TITLE
Add support for setRate on Android. Fix setRate on iOS when seeking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,7 @@ Stops recording an audio file.
 ### Supported Platforms
 
 - iOS
+- Android
 
 ### Parameters
 

--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -179,6 +179,10 @@ public class AudioHandler extends CordovaPlugin {
             callbackContext.sendPluginResult(new PluginResult(status, f));
             return true;
         }
+        else if (action.equals("setRate")) {
+            this.setRate(args.getString(0), Float.parseFloat(args.getString(1)));
+            return true;
+        }
         else { // Unrecognized action.
             return false;
         }
@@ -486,6 +490,23 @@ public class AudioHandler extends CordovaPlugin {
           LOG.e(TAG3,"Unknown Audio Player " + id);
         }
     }
+
+    /**
+     * Set the playback rate of an audio file
+     * 
+     * @param id   The id of the audio player
+     * @param rate The playback rate
+     */
+    public void setRate(String id, float rate) {
+        String TAG3 = "AudioHandler.setRate(): Error : ";
+        AudioPlayer audio = this.players.get(id);
+        if (audio != null) {
+            audio.setRate(rate);
+        } else {
+            LOG.e(TAG3, "Unknown Audio Player " + id);
+        }	        
+    }
+    
 
     private void onFirstPlayerCreated() {
         origVolumeStream = cordova.getActivity().getVolumeControlStream();

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -25,6 +25,7 @@ import android.media.MediaPlayer.OnErrorListener;
 import android.media.MediaPlayer.OnPreparedListener;
 import android.media.MediaRecorder;
 import android.os.Environment;
+import android.os.Build;
 
 import org.apache.cordova.LOG;
 
@@ -756,5 +757,21 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             }
         }
         return 0;
+    }
+
+    public void setRate(float speed) {
+        // Check for API 23+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            try {
+                boolean wasPlaying = this.player.isPlaying();
+                this.player.setPlaybackParams(this.player.getPlaybackParams().setSpeed(speed));
+                if (!wasPlaying && this.player.isPlaying()) {
+                    this.player.pause();
+                }
+            }
+            catch(Exception e) {
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -581,6 +581,7 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 
         BOOL isPlaying = (avPlayer.rate > 0 && !avPlayer.error);
         BOOL isReadyToSeek = (avPlayer.status == AVPlayerStatusReadyToPlay) && (avPlayer.currentItem.status == AVPlayerItemStatusReadyToPlay);
+        float currentPlaybackRate = avPlayer.rate;
 
         // CB-10535:
         // When dealing with remote files, we can get into a situation where we start playing before AVPlayer has had the time to buffer the file to be played.
@@ -590,7 +591,11 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
                  toleranceBefore: kCMTimeZero
                   toleranceAfter: kCMTimeZero
                completionHandler: ^(BOOL finished) {
-                   if (isPlaying) [avPlayer play];
+                   if (isPlaying) { 
+                       [avPlayer play];
+                       // [avPlayer play] sets the rate to 1, so we need to set it again after seeking
+                       [avPlayer setRate:currentPlaybackRate];
+                   };
                }];
         } else {
             NSString* errMsg = @"AVPlayerItem cannot service a seek request with a completion handler until its status is AVPlayerItemStatusReadyToPlay.";

--- a/www/Media.js
+++ b/www/Media.js
@@ -170,11 +170,7 @@ Media.prototype.setVolume = function(volume) {
  * Adjust the playback rate.
  */
 Media.prototype.setRate = function(rate) {
-    if (cordova.platformId === 'ios'){
-        exec(null, null, "Media", "setRate", [this.id, rate]);
-    } else {
-        console.warn('media.setRate method is currently not supported for', cordova.platformId, 'platform.');
-    }
+    exec(null, null, "Media", "setRate", [this.id, rate]);
 };
 
 /**


### PR DESCRIPTION
### Platforms affected
- Android
- iOS

### What does this PR do?
- Fix rate setting when seeking audio tracks on iOS.
- Adds setRate support for android.

### What testing has been done on this change?
Physical device testing on:

- iPhone X (iOS 12)
- iPhone 6 (iOS 11)
- OnePlus 5T (Oreo 8.1)
- Samsung Galaxy S8 (Nougat 7.1)

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
