### PR TITLE
Success callback is not called on Android when Activity is signaled to be destroyed.

### DIFF
--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -196,7 +196,7 @@ public class AudioHandler extends CordovaPlugin {
             onLastPlayerReleased();
         }
         for (AudioPlayer audio : this.players.values()) {
-            audio.destroy();
+            audio.onActivityDestroyed();
         }
         this.players.clear();
     }
@@ -273,7 +273,7 @@ public class AudioHandler extends CordovaPlugin {
         if (players.isEmpty()) {
             onLastPlayerReleased();
         }
-        audio.destroy();
+        audio.destroy(true);
         return true;
     }
 

--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -196,7 +196,7 @@ public class AudioHandler extends CordovaPlugin {
             onLastPlayerReleased();
         }
         for (AudioPlayer audio : this.players.values()) {
-            audio.onActivityDestroyed();
+            audio.onHandlerDestroyed();
         }
         this.players.clear();
     }


### PR DESCRIPTION
Success callback is not called on Android when Activity is signaled to be destroyed. Instead, an error message (ABORTED) is signaled to client. This helps to clear up the ambiguity during a common android activity life cycle event (onDestroy), because previously the client code was unable to discern the reason for a successful callback execution. The reasons for a success callback could possibly be for activity termination OR playback naturally coming to an end (EOF reached).