### PR TITLE
feat: Implement playing audio in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ The following constants are reported as the only parameter to the
 
 - `media.play`: Start or resume playing an audio file.
 
+- `media.playInBackground`: Start or resume playing an audio file in background.
+
 - `media.pause`: Pause playback of an audio file.
 
 - `media.pauseRecord`: Pause recording of an audio file.
@@ -364,6 +366,41 @@ function playAudio(url) {
         var myMedia = new Media("audio/beer.mp3")
         myMedia.play()  // first looks for file in www/audio/beer.mp3 then in <application>/documents/tmp/audio/beer.mp3
 
+## media.playInBackground
+
+Starts or resumes playing an audio file in background.
+
+```js
+media.playInBackground();
+```
+
+### Supported Platforms
+
+- Android
+- iOS
+
+### Quick Example
+
+```js
+// Play audio in background
+//
+function playAudioInBackground(url) {
+    // Play the audio file at url
+    var my_media = new Media(url,
+        // success callback
+        function () {
+            console.log("playAudioInBackground():Audio Success");
+        },
+        // error callback
+        function (err) {
+            console.log("playAudioInBackground():Audio Error: " + err);
+        }
+    );
+    // Play audio
+    my_media.playInBackground();
+}
+```
+
 ## media.release
 
 Releases the underlying operating system's audio resources.
@@ -556,7 +593,7 @@ function recordAudio() {
 
 This plugins requires the following usage description:
 
-* `NSMicrophoneUsageDescription` describes the reason that the app accesses the user's microphone. 
+* `NSMicrophoneUsageDescription` describes the reason that the app accesses the user's microphone.
 
 To add this entry into the `info.plist`, you can use the `edit-config` tag in the `config.xml` like this:
 

--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -137,6 +137,17 @@ public class AudioHandler extends CordovaPlugin {
             }
             this.startPlayingAudio(args.getString(0), FileHelper.stripFileProtocol(fileUriStr));
         }
+        else if (action.equals("startPlayingAudioInBackground")) {
+            String target = args.getString(1);
+            String fileUriStr;
+            try {
+                Uri targetUri = resourceApi.remapUri(Uri.parse(target));
+                fileUriStr = targetUri.toString();
+            } catch (IllegalArgumentException e) {
+                fileUriStr = target;
+            }
+            this.startPlayingAudioInBackground(args.getString(0), FileHelper.stripFileProtocol(fileUriStr));
+        }
         else if (action.equals("seekToAudio")) {
             this.seekToAudio(args.getString(0), args.getInt(1));
         }
@@ -319,6 +330,14 @@ public class AudioHandler extends CordovaPlugin {
         AudioPlayer audio = getOrCreatePlayer(id, file);
         audio.startPlaying(file);
         getAudioFocus();
+    }
+
+    public void startPlayingAudioInBackground(final String id, final String file) {
+      cordova.getThreadPool().execute(new Runnable() {
+        public void run() {
+          startPlayingAudio(id, file);
+        }
+      });
     }
 
     /**

--- a/src/ios/CDVSound.h
+++ b/src/ios/CDVSound.h
@@ -95,6 +95,7 @@ typedef NSUInteger CDVMediaMsg;
 @property (nonatomic, strong) NSString* statusCallbackId;
 
 - (void)startPlayingAudio:(CDVInvokedUrlCommand*)command;
+- (void)startPlayingAudioInBackground:(CDVInvokedUrlCommand*)command;
 - (void)pausePlayingAudio:(CDVInvokedUrlCommand*)command;
 - (void)stopPlayingAudio:(CDVInvokedUrlCommand*)command;
 - (void)seekToAudio:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -338,6 +338,11 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
     // don't care for any callbacks
 }
 
+- (void)startPlayingAudioInBackground:(CDVInvokedUrlCommand*)command
+{
+    [self startPlayingAudio:command];
+}
+
 - (void)startPlayingAudio:(CDVInvokedUrlCommand*)command
 {
     [self.commandDelegate runInBackground:^{
@@ -839,7 +844,7 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 {
     /* https://issues.apache.org/jira/browse/CB-11513 */
     NSMutableArray* keysToRemove = [[NSMutableArray alloc] init];
-    
+
     for(id key in [self soundCache]) {
         CDVAudioFile* audioFile = [[self soundCache] objectForKey:key];
         if (audioFile != nil) {
@@ -851,9 +856,9 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
             }
         }
     }
-    
+
     [[self soundCache] removeObjectsForKeys:keysToRemove];
-    
+
     // [[self soundCache] removeAllObjects];
     // [self setSoundCache:nil];
     [self setAvSession:nil];

--- a/www/Media.js
+++ b/www/Media.js
@@ -77,6 +77,13 @@ Media.prototype.play = function(options) {
 };
 
 /**
+ * Start or resume playing audio file in a background thread.
+ */
+Media.prototype.playInBackground = function(options) {
+    exec(null, null, "Media", "startPlayingAudioInBackground", [this.id, this.src, options]);
+};
+
+/**
  * Stop playing audio file.
  */
 Media.prototype.stop = function() {


### PR DESCRIPTION
### Platforms affected

* Android
* iOS

On iOS, I only added a `startPlayingAudioInBackground` that's a proxy to`startPlayingAudio` because the latter already plays the audio in a background thread.


### Motivation and Context

Playing audio in a separate thread on Android greatly improved the performance of our apps.

### Description

I added `Media.prototype.playInBackground` to the javascript interface.
I added the method `startPlayingAudioInBackground` to both Android and iOS native interfaces.


### Testing
The changes are pretty minimal. I installed the plugin in a new cordova project and tested it manually.
