### PR TITLE
fix(android): remove READ_PHONE_STATE permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,3 +1,4 @@
+
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
@@ -56,7 +57,6 @@ id="cordova-plugin-media"
             <uses-permission android:name="android.permission.RECORD_AUDIO" />
             <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.READ_PHONE_STATE" />
         </config-file>
 
         <source-file src="src/android/AudioHandler.java" target-dir="src/org/apache/cordova/media" />


### PR DESCRIPTION
### Platforms affected

* Android


### Motivation and Context

The plugin uses the `OnAudioFocusChangeListener` to listen to audio focus changes such as the ones that happen on incoming calls. There is no need to request the `android.permission.READ_PHONE_STATE` because it is not needed.
I think it's good to remove such permission because it has a _dangerous_ protection level.

### Description

Removed `<uses-permission android:name="android.permission.READ_PHONE_STATE" />` frrom `plugin.xml`

