### PR TITLE
Fix #248 delete javascript reference to released media

### DIFF
--- a/www/Media.js
+++ b/www/Media.js
@@ -156,7 +156,10 @@ Media.prototype.resumeRecord = function() {
  * Release the resources.
  */
 Media.prototype.release = function() {
-    exec(null, this.errorCallback, "Media", "release", [this.id]);
+    var me = this;
+    exec(function() {
+      delete mediaObjects[me.id];
+    }, this.errorCallback, "Media", "release", [this.id]);
 };
 
 /**


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All (www change)


### Motivation and Context
This removes the javascript reference to released media objects.  See #248 

### Description
Add a success callback to delete media id after it is released by platform specific code.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [NA ] I added automated test coverage as appropriate for this change
- [ NA] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [Y ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [NA ] I've updated the documentation if necessary
