### PR TITLE
fix: remove deprecated platform code snippets 

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -28,7 +28,7 @@ var ACTUAL_PLAYBACK_TEST_TIMEOUT = 2 * 60 * 1000;
 var WEB_MP3_FILE = 'https://cordova.apache.org/static/downloads/BlueZedEx.mp3';
 var WEB_MP3_STREAM = 'https://cordova.apache.org/static/downloads/BlueZedEx.mp3';
 
-var isWindows = cordova.platformId === 'windows8' || cordova.platformId === 'windows';
+var isWindows = cordova.platformId === 'windows';
 var isBrowser = cordova.platformId === 'browser';
 // Detect whether audio hardware is available and enabled. For iOS playing audio is
 // not supported on emulators w/out sound device connected to host PC but (which is
@@ -38,8 +38,6 @@ var isAudioSupported = isWindows
     : cordova.platformId === 'ios'
         ? !window.SAUCELABS_ENV
         : true;
-
-var isKitKat = cordova.platformId === 'android' && /Android\s4\.4/.test(window.navigator.userAgent);
 
 exports.defineAutoTests = function () {
     var failed = function (done, msg, context) {
@@ -200,11 +198,6 @@ exports.defineAutoTests = function () {
         });
 
         it('media.spec.18 should return MediaError for bad filename', function (done) {
-            // bb10 dialog pops up, preventing tests from running
-            if (cordova.platformId === 'blackberry10') {
-                pending();
-            }
-
             var context = this;
             var fileName = 'invalid.file.name';
             var badMedia = new Media(
@@ -245,7 +238,7 @@ exports.defineAutoTests = function () {
                 'media.spec.19 position should be set properly',
                 function (done) {
                     // no audio hardware available
-                    if (!isAudioSupported || isBrowser || isKitKat) {
+                    if (!isAudioSupported || isBrowser) {
                         pending();
                     }
 
@@ -283,7 +276,7 @@ exports.defineAutoTests = function () {
             it(
                 'media.spec.20 duration should be set properly',
                 function (done) {
-                    if (!isAudioSupported || cordova.platformId === 'blackberry10' || isBrowser || isKitKat) {
+                    if (!isAudioSupported || isBrowser) {
                         pending();
                     }
 
@@ -321,7 +314,7 @@ exports.defineAutoTests = function () {
             it(
                 'media.spec.21 should be able to resume playback after pause',
                 function (done) {
-                    if (!isAudioSupported || cordova.platformId === 'blackberry10' || isKitKat || isBrowser) {
+                    if (!isAudioSupported || isBrowser) {
                         /**
                          * Browser Error:
                          * Uncaught (in promise) DOMException: play() failed because the user didn't interact with
@@ -387,7 +380,7 @@ exports.defineAutoTests = function () {
             it(
                 'media.spec.22 should be able to seek through file',
                 function (done) {
-                    if (!isAudioSupported || cordova.platformId === 'blackberry10' || isKitKat || isBrowser) {
+                    if (!isAudioSupported || isBrowser) {
                         /**
                          * Browser Error:
                          * Uncaught (in promise) DOMException: play() failed because the user didn't interact with
@@ -508,7 +501,7 @@ exports.defineAutoTests = function () {
             function (done) {
                 // no audio hardware available, OR
                 // O_o Safari can't play the stream, so we're skipping this test on all browsers o_O
-                if (!isAudioSupported || isBrowser || isKitKat) {
+                if (!isAudioSupported || isBrowser) {
                     pending();
                 }
 
@@ -544,11 +537,6 @@ exports.defineAutoTests = function () {
         );
 
         it('media.spec.26 should not crash or throw when setting the volume right after creating the media', function (done) {
-            // bb10 dialog pops up, preventing tests from running
-            if (cordova.platformId === 'blackberry10') {
-                pending();
-            }
-
             var mediaFile = WEB_MP3_FILE;
             var media = null;
 
@@ -567,8 +555,7 @@ exports.defineAutoTests = function () {
         });
 
         it('media.spec.27 should call success or error when trying to stop a media that is in starting state', function (done) {
-            // bb10 dialog pops up, preventing tests from running
-            if (!isAudioSupported || cordova.platformId === 'blackberry10' || isBrowser) {
+            if (!isAudioSupported || isBrowser) {
                 /**
                  * Browser Error:
                  * Uncaught (in promise) DOMException: play() failed because the user didn't interact with
@@ -920,27 +907,6 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         );
     }
 
-    // Function to create a file for BB recording
-    function getRecordSrcBB () {
-        var fsFail = function (error) {
-            console.log('error creating file for BB recording', error);
-        };
-        var gotFile = function (file) {
-            recordSrc = file.fullPath;
-        };
-        var gotFS = function (fileSystem) {
-            fileSystem.root.getFile(
-                'BBRecording.amr',
-                {
-                    create: true
-                },
-                gotFile,
-                fsFail
-            );
-        };
-        window.requestFileSystem(LocalFileSystem.TEMPORARY, 0, gotFS, fsFail);
-    }
-
     // Function to create a file for Windows recording
     function getRecordSrcWin () {
         var fsFail = function (error) {
@@ -1262,12 +1228,10 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         },
         'setVolumeBtn'
     );
-    // get Special path to record if iOS || Blackberry
+    // get Special path to record if iOS
     if (cordova.platformId === 'ios') {
         getRecordSrc();
-    } else if (cordova.platformId === 'blackberry') {
-        getRecordSrcBB();
-    } else if (cordova.platformId === 'windows' || cordova.platformId === 'windows8') {
+    } else if (cordova.platformId === 'windows') {
         getRecordSrcWin();
     }
 

--- a/www/Media.js
+++ b/www/Media.js
@@ -276,7 +276,7 @@ function onMessageFromNative (msg) {
     }
 }
 
-if (cordova.platformId === 'android' || cordova.platformId === 'amazon-fireos' || cordova.platformId === 'windowsphone') {
+if (cordova.platformId === 'android') {
     var channel = require('cordova/channel');
 
     channel.createSticky('onMediaPluginReady');


### PR DESCRIPTION
### Motivation and Context

Removes references to removed platforms. Should have been part of #157. Depends on #283.