### PR TITLE
Android 11 compatibility

### DIFF
--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -81,6 +81,10 @@ public class AudioHandler extends CordovaPlugin {
         this.pausedForFocus = new ArrayList<AudioPlayer>();
     }
 
+    public Context getApplicationContext()
+    {
+        return this.cordova.getActivity().getApplicationContext();
+    }
 
     protected void getWritePermission(int requestCode)
     {

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -25,6 +25,7 @@ import android.media.MediaPlayer.OnErrorListener;
 import android.media.MediaPlayer.OnPreparedListener;
 import android.media.MediaRecorder;
 import android.os.Environment;
+import android.content.Context;
 
 import org.apache.cordova.LOG;
 
@@ -107,12 +108,9 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     }
 
     private String generateTempFile() {
-      String tempFileName = null;
-      if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
-          tempFileName = Environment.getExternalStorageDirectory().getAbsolutePath() + "/tmprecording-" + System.currentTimeMillis() + ".3gp";
-      } else {
-          tempFileName = "/data/data/" + handler.cordova.getActivity().getPackageName() + "/cache/tmprecording-" + System.currentTimeMillis() + ".3gp";
-      }
+      Context context = this.handler.getApplicationContext();
+      String tempFileName = context.getFilesDir().getAbsolutePath() + "/tmprecording-" + System.currentTimeMillis() + ".3gp";
+
       return tempFileName;
     }
 
@@ -185,11 +183,8 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         /* this is a hack to save the file as the specified name */
 
         if (!file.startsWith("/")) {
-            if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
-                file = Environment.getExternalStorageDirectory().getAbsolutePath() + File.separator + file;
-            } else {
-                file = "/data/data/" + handler.cordova.getActivity().getPackageName() + "/cache/" + file;
-            }
+            Context context = this.handler.getApplicationContext();
+            file = context.getFilesDir().getAbsolutePath() + File.separator + file;
         }
 
         int size = this.tempFiles.size();


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context

Fixes compatibility with Android 11, specifically https://github.com/apache/cordova-plugin-media/issues/314

### Description

Android 11 no longer supports the  Environment.getExternalStorageDirectory() method, so this has been replaced with getFilesDir() to store the file into the app internal storage instead.

### Testing

I've deployed this onto a physical Android 11 device, then started an audio recording and completed the recording to ensure the file is accessible and contains data.

See my comments in the linked issue for the error I was solving, along with the backtrace.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
