### PR TITLE
fix(android): getting external files directory for Android 10+

### DIFF
--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -81,6 +81,9 @@ public class AudioHandler extends CordovaPlugin {
         this.pausedForFocus = new ArrayList<AudioPlayer>();
     }
 
+    public Context getApplicationContext() {
+        return cordova.getActivity().getApplicationContext();
+    }
 
     protected void getWritePermission(int requestCode)
     {

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -117,15 +117,15 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
      * @return
      */
     private String createAudioFilePath(String fileName) {
-        String filePath = Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)
-            ? context.getExternalFilesDir(null).getAbsolutePath()
-            : context.getCacheDir().getAbsolutePath();
+        File dir = Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)
+            ? context.getExternalFilesDir(null)
+            : context.getCacheDir();
 
         fileName = fileName.isEmpty()
             ? String.format("tmprecording-%d.3gp", System.currentTimeMillis())
             : fileName;
 
-        return filePath + File.separator + fileName;
+        return dir.getAbsolutePath() + File.separator + fileName;
     }
 
     /**

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -114,7 +114,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
      * Creates an audio file path from the provided fileName or creates a new temporary file path.
      *
      * @param fileName the audio file name, if null a temporary 3gp file name is provided
-     * @return
+     * @return String
      */
     private String createAudioFilePath(String fileName) {
         File dir = Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -111,21 +111,21 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     }
 
     /**
-     * Creates an Audio File Path from the provided fileName or provides a new temporary file path.
+     * Creates an audio file path from the provided fileName or creates a new temporary file path.
      *
      * @param fileName the audio file name, if null a temporary 3gp file name is provided
      * @return
      */
     private String createAudioFilePath(String fileName) {
-        String tempFileNamePrefix = Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)
+        String filePath = Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)
             ? context.getExternalFilesDir(null).getAbsolutePath()
             : context.getCacheDir().getAbsolutePath();
 
-        String tempFileNameSuffix = fileName.isEmpty()
+        fileName = fileName.isEmpty()
             ? String.format("tmprecording-%l.3gp", System.currentTimeMillis())
             : fileName;
 
-        return tempFileNamePrefix + File.separator + tempFileNameSuffix;
+        return filePath + File.separator + fileName;
     }
 
     /**

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -122,7 +122,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             : context.getCacheDir().getAbsolutePath();
 
         fileName = fileName.isEmpty()
-            ? String.format("tmprecording-%l.3gp", System.currentTimeMillis())
+            ? String.format("tmprecording-%d.3gp", System.currentTimeMillis())
             : fileName;
 
         return filePath + File.separator + fileName;

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -18,6 +18,7 @@
 */
 package org.apache.cordova.media;
 
+import android.content.Context;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnCompletionListener;
@@ -78,6 +79,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
 //    private static int MEDIA_ERR_NONE_SUPPORTED = 4;
 
     private AudioHandler handler;           // The AudioHandler object
+    private Context context;                // The Application Context object
     private String id;                      // The id of this player (used to identify Media object in JavaScript)
     private MODE mode = MODE.NONE;          // Playback or Recording mode
     private STATE state = STATE.MEDIA_NONE; // State of recording or playback
@@ -101,19 +103,29 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
      */
     public AudioPlayer(AudioHandler handler, String id, String file) {
         this.handler = handler;
+        context = handler.getApplicationContext();
         this.id = id;
         this.audioFile = file;
         this.tempFiles = new LinkedList<String>();
+
     }
 
-    private String generateTempFile() {
-      String tempFileName = null;
-      if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
-          tempFileName = Environment.getExternalStorageDirectory().getAbsolutePath() + "/tmprecording-" + System.currentTimeMillis() + ".3gp";
-      } else {
-          tempFileName = "/data/data/" + handler.cordova.getActivity().getPackageName() + "/cache/tmprecording-" + System.currentTimeMillis() + ".3gp";
-      }
-      return tempFileName;
+    /**
+     * Creates an Audio File Path from the provided fileName or provides a new temporary file path.
+     *
+     * @param fileName the audio file name, if null a temporary 3gp file name is provided
+     * @return
+     */
+    private String createAudioFilePath(String fileName) {
+        String tempFileNamePrefix = Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)
+            ? context.getExternalFilesDir(null).getAbsolutePath()
+            : context.getCacheDir().getAbsolutePath();
+
+        String tempFileNameSuffix = fileName.isEmpty()
+            ? String.format("tmprecording-%l.3gp", System.currentTimeMillis())
+            : fileName;
+
+        return tempFileNamePrefix + File.separator + tempFileNameSuffix;
     }
 
     /**
@@ -155,7 +167,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             this.recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
             this.recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS); // RAW_AMR);
             this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC); //AMR_NB);
-            this.tempFile = generateTempFile();
+            this.tempFile = createAudioFilePath(null);
             this.recorder.setOutputFile(this.tempFile);
             try {
                 this.recorder.prepare();
@@ -185,11 +197,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         /* this is a hack to save the file as the specified name */
 
         if (!file.startsWith("/")) {
-            if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
-                file = Environment.getExternalStorageDirectory().getAbsolutePath() + File.separator + file;
-            } else {
-                file = "/data/data/" + handler.cordova.getActivity().getPackageName() + "/cache/" + file;
-            }
+            file = createAudioFilePath(file);
         }
 
         int size = this.tempFiles.size();


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context

To resolve mounted storage for Android 11. 
Android 11 (API 30) has deprecated the method `Environment.getExternalStorageDirectory()`.

### Description

This PR has replaced the `Environment.getExternalStorageDirectory()` usage with `context.getExternalFilesDir(null)`.

Per Android documentation, `getExternalFilesDir` is one of the suggested alternative solutions.

PR also includes a little bit of refactoring to remove code duplication that related to the calling of `getExternalStorageDirectory`, now `getExternalFilesDir`.

### Testing

- In-Progress...

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
