### PR TITLE
test(browser): disable test cases w/ play() due to Autoplay Policy

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -321,7 +321,21 @@ exports.defineAutoTests = function () {
             it(
                 'media.spec.21 should be able to resume playback after pause',
                 function (done) {
-                    if (!isAudioSupported || cordova.platformId === 'blackberry10' || isKitKat) {
+                    if (!isAudioSupported || cordova.platformId === 'blackberry10' || isKitKat || isBrowser) {
+                        /**
+                         * Browser Error:
+                         * Uncaught (in promise) DOMException: play() failed because the user didn't interact with
+                         * the document first. https://goo.gl/xX8pDD
+                         *
+                         * The Autoplay Policy launched in Chrome 66 for audio and video elements and is effectively
+                         * blocking roughly half of unwanted media autoplays in Chrome. For the Web Audio API, the
+                         * autoplay policy launched in Chrome 71. This affects web games, some WebRTC applications,
+                         * and other web pages using audio features. More details can be found in the Web Audio API
+                         * section below.
+                         *
+                         * Due to the Chrome Policies, this test is disabled because it can not be run without user
+                         * interations.
+                         */
                         pending();
                     }
 
@@ -373,7 +387,21 @@ exports.defineAutoTests = function () {
             it(
                 'media.spec.22 should be able to seek through file',
                 function (done) {
-                    if (!isAudioSupported || cordova.platformId === 'blackberry10' || isKitKat) {
+                    if (!isAudioSupported || cordova.platformId === 'blackberry10' || isKitKat || isBrowser) {
+                        /**
+                         * Browser Error:
+                         * Uncaught (in promise) DOMException: play() failed because the user didn't interact with
+                         * the document first. https://goo.gl/xX8pDD
+                         *
+                         * The Autoplay Policy launched in Chrome 66 for audio and video elements and is effectively
+                         * blocking roughly half of unwanted media autoplays in Chrome. For the Web Audio API, the
+                         * autoplay policy launched in Chrome 71. This affects web games, some WebRTC applications,
+                         * and other web pages using audio features. More details can be found in the Web Audio API
+                         * section below.
+                         *
+                         * Due to the Chrome Policies, this test is disabled because it can not be run without user
+                         * interations.
+                         */
                         pending();
                     }
 
@@ -540,7 +568,21 @@ exports.defineAutoTests = function () {
 
         it('media.spec.27 should call success or error when trying to stop a media that is in starting state', function (done) {
             // bb10 dialog pops up, preventing tests from running
-            if (!isAudioSupported || cordova.platformId === 'blackberry10') {
+            if (!isAudioSupported || cordova.platformId === 'blackberry10' || isBrowser) {
+                /**
+                 * Browser Error:
+                 * Uncaught (in promise) DOMException: play() failed because the user didn't interact with
+                 * the document first. https://goo.gl/xX8pDD
+                 *
+                 * The Autoplay Policy launched in Chrome 66 for audio and video elements and is effectively
+                 * blocking roughly half of unwanted media autoplays in Chrome. For the Web Audio API, the
+                 * autoplay policy launched in Chrome 71. This affects web games, some WebRTC applications,
+                 * and other web pages using audio features. More details can be found in the Web Audio API
+                 * section below.
+                 *
+                 * Due to the Chrome Policies, this test is disabled because it can not be run without user
+                 * interations.
+                 */
                 pending();
             }
 


### PR DESCRIPTION
### Platforms affected

Browser (Test Specs)

### Motivation and Context

Test failing due to Chrome's Autoplay Policy

### Description

This PR disables test case 21, 22, and 27 because these calls `play()` method which is against Chrome's Autoplay Policy.

**The Error:**

> Uncaught (in promise) DOMException: play() failed because the user didn't interact with the document first. https://goo.gl/xX8pDD

**The Reason:**

> The Autoplay Policy launched in Chrome 66 for audio and video elements and is effectively blocking roughly half of unwanted media autoplays in Chrome. For the Web Audio API, the autoplay policy launched in Chrome 71. This affects web games, some WebRTC applications, and other web pages using audio features. More details can be found in the Web Audio API section below.

### Testing

- CI

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
