### PR TITLE
feat(ios): support file scheme

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -24,6 +24,7 @@
 #define HTTP_SCHEME_PREFIX @"http://"
 #define HTTPS_SCHEME_PREFIX @"https://"
 #define CDVFILE_PREFIX @"cdvfile://"
+#define FILE_PREFIX @"file://"
 
 @implementation CDVSound
 
@@ -70,6 +71,9 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
             resourceURL = [NSURL URLWithString:resourcePath];
         }
     } else {
+        if ([resourcePath hasPrefix:FILE_PREFIX]) { // Support file scheme
+            resourcePath = [resourcePath substringFromIndex:[FILE_PREFIX length]];
+        }
         // if resourcePath is not from FileSystem put in tmp dir, else attempt to use provided resource path
         NSString* tmpPath = [NSTemporaryDirectory()stringByStandardizingPath];
         BOOL isTmp = [resourcePath rangeOfString:tmpPath].location != NSNotFound;
@@ -114,6 +118,9 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
             resourceURL = [NSURL URLWithString:resourcePath];
         }
     } else {
+        if ([resourcePath hasPrefix:FILE_PREFIX]) { // Support file scheme
+            resourcePath = [resourcePath substringFromIndex:[FILE_PREFIX length]];
+        }
         // attempt to find file path in www directory or LocalFileSystem.TEMPORARY directory
         filePath = [self.commandDelegate pathForResource:resourcePath];
         if (filePath == nil) {


### PR DESCRIPTION

### Platforms affected

iOS platform

### Motivation and Context

In iOS, this plugin does not support `file://` scheme.
Therefore following code does not work
```
  window.requestFileSystem(
      LocalFileSystem.PERSISTENT,
      0,
      function (fs) {
          const pathPrefix = fs.root.toURL();
          file = pathPrefix + fileName;
          mediaRec = new Media(file, mediaRecordSuccess, mediaError, mediaRecordStatus);
          mediaRec.startRecord();
      },
      function (err) {
          alert("LocalFileSystem Error");
      }
  );
```
On the other hand, this code works in Android.

The actual `file` variable in the above code is like `file:///var/mobile/Containers/Data/Application/6DAC6E88-C38A-4A8B-A7E9-456345E5D25D/Library/NoCloud/myrecording.m4a` where the `file://` scheme is used.
But the current this plugin does not support `file://` scheme in iOS and not work in iOS.

This is inconsistent with in Android.

### Description
This PR improves Media plugin to support `file://` scheme in iOS.

### Testing

In my local Mac, I create a sample cordova project and add this modified media plugin.
Check the Recording and Playing audio with file path using `file://` scheme and confirm it works well.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary


