### PR TITLE
fix(ios): error on getPosition when time is nan

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -659,6 +659,10 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
        position = CMTimeGetSeconds(time);
     }
 
+    if (isnan(position)){
+        position = -1;
+    }
+
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:position];
 
     [self onStatus:MEDIA_POSITION mediaId:mediaId param:@(position)];


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

ios

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

resolves #165
→ CB-13852

### Description
<!-- Describe your changes in detail -->

See #165

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
