### PR TITLE
test(spec.22): pause media before calling getCurrentPosition

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -435,6 +435,7 @@ exports.defineAutoTests = function () {
                             checkInterval = setInterval(function () {
                                 if (context.done) return;
                                 media.seekTo(5000);
+                                media.pause(); // pause media before confirming if it seeked to 5 seconds against current position.
                                 media.getCurrentPosition(function (position) {
                                     expect(position).toBeCloseTo(5, 0);
                                     context.done = true;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

test

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

GH Actions CI Test against iOS 13 was failing to determin if the audio was seeked.

Manually testing the seeking feature while audio is playing worked but appears to have a race condition with in the CI for iOS 13.

### Description
<!-- Describe your changes in detail -->

I changed the behavior of the test to pause the audio immediately after seeking before getting the current position to confirm that it seeked.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual and GH Actions

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
