### PR TITLE
test(spec.timeout): try to improve against timeout failures

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -264,7 +264,9 @@ exports.defineAutoTests = function () {
                     // Some information about this kind of behaviour can be found at JIRA: CB-7099.
                     var context = this;
                     var mediaFile = WEB_MP3_FILE;
-                    var successCallback = function () {};
+                    var successCallback = function () {
+                        done();
+                    };
                     var statusChange = function (statusCode) {
                         if (!context.done && statusCode === Media.MEDIA_RUNNING) {
                             checkInterval = setInterval(function () {
@@ -302,7 +304,9 @@ exports.defineAutoTests = function () {
                     // Some information about this kind of behaviour can be found at JIRA: CB-7099.
                     var context = this;
                     var mediaFile = WEB_MP3_FILE;
-                    var successCallback = function () {};
+                    var successCallback = function () {
+                        done();
+                    };
                     var statusChange = function (statusCode) {
                         if (!context.done && statusCode === Media.MEDIA_RUNNING) {
                             checkInterval = setInterval(function () {
@@ -355,7 +359,9 @@ exports.defineAutoTests = function () {
                     var context = this;
                     var resumed = false;
                     var mediaFile = WEB_MP3_FILE;
-                    var successCallback = function () {};
+                    var successCallback = function () {
+                        done();
+                    };
                     var statusChange = function (statusCode) {
                         if (context.done) return;
 
@@ -420,7 +426,9 @@ exports.defineAutoTests = function () {
                     // Some information about this kind of behaviour can be found at JIRA: CB-7099.
                     var context = this;
                     var mediaFile = WEB_MP3_FILE;
-                    var successCallback = function () {};
+                    var successCallback = function () {
+                        done();
+                    };
                     var statusChange = function (statusCode) {
                         if (!context.done && statusCode === Media.MEDIA_RUNNING) {
                             checkInterval = setInterval(function () {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -234,14 +234,22 @@ exports.defineAutoTests = function () {
         describe('actual playback', function () {
             var checkInterval, media;
 
-            afterEach(function () {
-                clearInterval(checkInterval);
+            // Ensure interval and media is cleared out before and after each test
+            var safeDone = function () {
+                if (checkInterval) {
+                    clearInterval(checkInterval);
+                    checkInterval = null;
+                }
+
                 if (media) {
                     media.stop();
                     media.release();
                     media = null;
                 }
-            });
+            };
+
+            afterEach(function () { safeDone(); });
+            beforeEach(function () { safeDone(); });
 
             it(
                 'media.spec.19 position should be set properly',

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -24,6 +24,7 @@
 // increased timeout for actual playback to give device chance to download and play mp3 file
 // some emulators can be REALLY slow at this, so two minutes
 var ACTUAL_PLAYBACK_TEST_TIMEOUT = 2 * 60 * 1000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = ACTUAL_PLAYBACK_TEST_TIMEOUT;
 
 var WEB_MP3_FILE = 'https://cordova.apache.org/static/downloads/BlueZedEx.mp3';
 var WEB_MP3_STREAM = 'https://cordova.apache.org/static/downloads/BlueZedEx.mp3';


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

test

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

GH Actions CI appears to hit timeout limits.

### Description
<!-- Describe your changes in detail -->

I made sure the done function was called in success callback, if called, objects cleared in both before and after each, and set the jasmine default timeout to match against the playback test timeout.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual and GH Actions: 
 - https://github.com/erisu/cordova-plugin-media/actions/runs/2962107380
 - https://github.com/erisu/cordova-plugin-media/actions/runs/2962107378

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
