### PR TITLE
feat(ios): load media files with custom scheme+hostname and leading directory paths

### DIFF
--- a/src/ios/CDVSound.h
+++ b/src/ios/CDVSound.h
@@ -15,6 +15,7 @@
  under the License.
  */
 
+@import WebKit;
 #import <Foundation/Foundation.h>
 #import <AudioToolbox/AudioServices.h>
 #import <AVFoundation/AVFoundation.h>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

ios

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Able to load media file paths that are written in custom scheme+hostname format or with a leading slash to represent root directory of "www"

### Description
<!-- Describe your changes in detail -->

Updated conditional checks

### Testing
<!-- Please describe in detail how you tested your changes. -->

```js
// const mediaFile = "https://www...wav";
// const mediaFile = cordova.file.applicationDirectory + '/www/media/test.wav';
// const mediaFile = 'app://localhost/media/test.wav';
const mediaFile = '/media/test.wav';

const myMedia = new Media(mediaFile, onSuccess, onError);
myMedia.play();
```

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
