### PR TITLE
fix (ios): update audio session configuration so audio can start to play when app in background

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -378,7 +378,13 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
                 }
 
                 NSString* sessionCategory = bPlayAudioWhenScreenIsLocked ? AVAudioSessionCategoryPlayback : AVAudioSessionCategorySoloAmbient;
-                [self.avSession setCategory:sessionCategory error:&err];
+                UIApplicationState state = [UIApplication sharedApplication].applicationState;
+                if (state == UIApplicationStateBackground) {
+                    [self.avSession setCategory:sessionCategory withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&err];
+                } else {
+                    [self.avSession setCategory:sessionCategory error:&err];
+                }
+
                 if (![self.avSession setActive:YES error:&err]) {
                     // other audio with higher priority that does not allow mixing could cause this to fail
                     NSLog(@"Unable to play audio: %@", [err localizedFailureReason]);


### PR DESCRIPTION
ios only: sound not playing when app is in background and some other app has sound on (#369)

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
ios


### Motivation and Context
The audio would not start if app is in background and some other app audio is running.
Reported issue:
https://github.com/apache/cordova-plugin-media/issues/369

### Description
update audio session with withOptions:AVAudioSessionCategoryOptionMixWithOthers so that we can play audio on top of other audio when our app is in background

### Testing
I have tested the changes on my ios app. 

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary