### PR TITLE
Fix for WRITE_EXTERNAL_STORAGE Android API 33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ bin
 .project
 .classpath
 
-
+.history
 
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ bin
 .project
 .classpath
 
-.history
+
 
 
 

--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -559,22 +559,27 @@ public class AudioHandler extends CordovaPlugin {
      * This little utility method catch-all work great for multi-permission stuff.
      *
      */
-
     private void promptForRecord()
     {
-        if(PermissionHelper.hasPermission(this, permissions[WRITE_EXTERNAL_STORAGE])  &&
-                PermissionHelper.hasPermission(this, permissions[RECORD_AUDIO])) {
-            this.startRecordingAudio(recordId, FileHelper.stripFileProtocol(fileUriStr));
+         //On ANDROID 13+ WRITE_EXTERNAL_STORAGE will always be denied
+        if (Build.VERSION.SDK_INT >= 33){
+            if (PermissionHelper.hasPermission(this, permissions[RECORD_AUDIO])) {
+                this.startRecordingAudio(recordId, FileHelper.stripFileProtocol(fileUriStr));
+            } else {
+                getMicPermission(RECORD_AUDIO);
+            }
         }
-        else if(PermissionHelper.hasPermission(this, permissions[RECORD_AUDIO]))
-        {
-            getWritePermission(WRITE_EXTERNAL_STORAGE);
+        else {
+            //legacy permissions (ANDROID 12 or lower)
+            if (PermissionHelper.hasPermission(this, permissions[WRITE_EXTERNAL_STORAGE]) &&
+                    PermissionHelper.hasPermission(this, permissions[RECORD_AUDIO])) {
+                this.startRecordingAudio(recordId, FileHelper.stripFileProtocol(fileUriStr));
+            } else if (PermissionHelper.hasPermission(this, permissions[RECORD_AUDIO])) {
+                getWritePermission(WRITE_EXTERNAL_STORAGE);
+            } else {
+                getMicPermission(RECORD_AUDIO);
+            }
         }
-        else
-        {
-            getMicPermission(RECORD_AUDIO);
-        }
-
     }
 
     /**

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -170,9 +170,9 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
              // support to record AAC with 44100 audio sampling
             this.recorder.setAudioSamplingRate(44100);
             this.recorder.setAudioEncodingBitRate(96000);
+             this.recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
             this.recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
             this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
-            this.recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
           //  this.recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS); // RAW_AMR);
           //  this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC); //AMR_NB);
             this.tempFile = createAudioFilePath(null);

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -167,10 +167,15 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
         case NONE:
             this.audioFile = file;
             this.recorder = new MediaRecorder();
+             // support to record AAC with 44100 audio sampling
+            this.recorder.setAudioSamplingRate(44100);
+            this.recorder.setAudioEncodingBitRate(96000);
+            this.recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
+            this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
             this.recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
-            this.recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS); // RAW_AMR);
-            this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC); //AMR_NB);
-            this.tempFile = createAudioFilePath(null);
+          //  this.recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS); // RAW_AMR);
+          //  this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC); //AMR_NB);
+            this.tempFile = generateTempFile();
             this.recorder.setOutputFile(this.tempFile);
             try {
                 this.recorder.prepare();

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -175,7 +175,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             this.recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
           //  this.recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS); // RAW_AMR);
           //  this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC); //AMR_NB);
-            this.tempFile = generateTempFile();
+            this.tempFile = createAudioFilePath(null);
             this.recorder.setOutputFile(this.tempFile);
             try {
                 this.recorder.prepare();


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

WRITE_EXTERNAL_STORAGE is always denied on Android 13+ when compiling against API 33

### Description
<!-- Describe your changes in detail -->

Checking API level at runtime to avoid asking for the WRITE_EXTERNAL_STORAGE permission

### Testing
<!-- Please describe in detail how you tested your changes. -->

Android 13 and Android 11 devices


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
