### PR TITLE
(android) Simple fix to handle new write permissions schemas on Android 13 (TIRAMISU)

### DIFF
--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -562,8 +562,10 @@ public class AudioHandler extends CordovaPlugin {
 
     private void promptForRecord()
     {
-        if(PermissionHelper.hasPermission(this, permissions[WRITE_EXTERNAL_STORAGE])  &&
-                PermissionHelper.hasPermission(this, permissions[RECORD_AUDIO])) {
+        boolean hasWritePermissions = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU 
+            || PermissionHelper.hasPermission(this, permissions[WRITE_EXTERNAL_STORAGE]);
+
+        if(hasWritePermissions  && PermissionHelper.hasPermission(this, permissions[RECORD_AUDIO])) {
             this.startRecordingAudio(recordId, FileHelper.stripFileProtocol(fileUriStr));
         }
         else if(PermissionHelper.hasPermission(this, permissions[RECORD_AUDIO]))
@@ -574,7 +576,6 @@ public class AudioHandler extends CordovaPlugin {
         {
             getMicPermission(RECORD_AUDIO);
         }
-
     }
 
     /**


### PR DESCRIPTION
This PR is intended to fix an issue with recording audio in Android 13 onwards

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Audio cannot be recorded using the method promptForRecord of the plugin, because of the changes made in Android 13 for the WRITE_EXTERNAL_STORAGE permissions, which always is denied in Android 13

### Description

This PR contributes a simple edit to the method promptForRecord of the AudioHandler class, which makes it always evaluate 
 to true when the plugin checks if the app has the permission WRITE_EXTERNAL_STORAGE in Android 13. Previous Android versions should behave just like before.

### Testing

I tested the change using the plugin in a android app project, where we use the plugin to record audio in various places, with my Android 13 enabled tablet and previous behaviour was tested with my Android 12 phone.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
