### PR TITLE
feat(android): increase audio encoding bitrate and sampling rate

### DIFF
--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -170,6 +170,8 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             this.recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
             this.recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS); // RAW_AMR);
             this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC); //AMR_NB);
+            this.recorder.setAudioEncodingBitRate(96000);
+            this.recorder.setAudioSamplingRate(44100);
             this.tempFile = createAudioFilePath(null);
             this.recorder.setOutputFile(this.tempFile);
             try {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Improve audio recording quality

Closes #331 

Note: This PR is setting the bitrate to 96 Kbps and not 128 Kbps. This plugin uses the AAC encoder, which generally provides better quality audio at a lower bitrate compared against MP3 encoder. While researching acceptable bitrate of AAC compared against MP3, some suggest using 96 Kbps for AAC while MP3 would be 128 Kbps. But this does not mean it is identical. In terms of quality, it will always result in source and equiptment.

### Description
<!-- Describe your changes in detail -->

Increased following settings:

- Audio BitRate -> `96000` (96 Kbps)
- Audio Sampling Rate -> `44100` (44.1 kHz)

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Tested recording audio on Google Pixel 6a (Android 13) device.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
